### PR TITLE
Add D CI workflow and example

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,3 +12,4 @@ function unstash {
 trap unstash EXIT
 
 ./gradlew check test -q
+dub test -q

--- a/.github/workflows/dub.yml
+++ b/.github/workflows/dub.yml
@@ -1,0 +1,15 @@
+name: D CI with Dub
+
+on: [ push, pull_request ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install D compiler
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: dmd-latest
+      - name: Run tests
+        run: dub test

--- a/README.adoc
+++ b/README.adoc
@@ -24,3 +24,11 @@ LMAX Development Team
 * https://github.com/LMAX-Exchange/disruptor/wiki/Frequently-Asked-Questions[FAQ]
 
 
+
+== Environment Prerequisites
+
+To build and test the project locally you will need:
+
+* A D compiler such as `dmd` or `ldc` along with `dub`
+* Java 11 or newer
+* Gradle (the wrapper `./gradlew` is provided)

--- a/TODO.md
+++ b/TODO.md
@@ -29,3 +29,6 @@ The Java sources under `src/main/java/com/lmax/disruptor` form the reference imp
 - [ ] Translate the modules listed above to D, starting with the ring buffer and sequencing logic.
 - [ ] Write D unit tests mirroring the Java tests in `src/test/java`.
 - [ ] Configure GitHub Actions to run `dub test` for the D build.
+- [ ] Update `.githooks/pre-commit` to run `dub test` in addition to Gradle checks.
+- [ ] Document required tools: a D compiler with `dub`, Java and Gradle.
+- [ ] Add a simple D example showing how to use the port.

--- a/examples/basic_usage.d
+++ b/examples/basic_usage.d
@@ -1,0 +1,8 @@
+import std.stdio;
+import disruptor; // placeholder import for the future library
+
+/// Simple example program.
+void main()
+{
+    writeln("Disruptor D port example");
+}


### PR DESCRIPTION
## Summary
- document requirements for Java, Gradle and D
- add CI workflow running `dub test`
- run `dub test` from `.githooks/pre-commit`
- add a simple D usage example
- track these tasks in TODO

## Testing
- `./gradlew test`
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_686cdae4d1d4832c8ac78c9621fed8f3