### PR TITLE
Add initial D Sequence and Sequencer

### DIFF
--- a/source/disruptor/package.d
+++ b/source/disruptor/package.d
@@ -1,1 +1,3 @@
+module disruptor;
+
 // Disruptor port in D - work in progress

--- a/source/disruptor/sequence.d
+++ b/source/disruptor/sequence.d
@@ -1,0 +1,77 @@
+module disruptor.sequence;
+
+import core.atomic;
+import std.conv : to;
+
+/// Concurrent sequence class similar to the Java version.
+class Sequence
+{
+    /// Initial value used by sequencers
+    enum long INITIAL_VALUE = -1;
+
+private:
+    // Padding on either side of the value to avoid false sharing.
+    long[7] _pad1 = 0;
+    shared long _value = INITIAL_VALUE;
+    long[7] _pad2 = 0;
+
+public:
+    this(long initialValue = INITIAL_VALUE) shared
+    {
+        atomicStore!(MemoryOrder.rel)(_value, initialValue);
+    }
+
+    long get() const shared @nogc nothrow
+    {
+        return atomicLoad!(MemoryOrder.acq)(_value);
+    }
+
+    void set(long v) shared @nogc nothrow
+    {
+        atomicStore!(MemoryOrder.rel)(_value, v);
+    }
+
+    void setVolatile(long v) shared @nogc nothrow
+    {
+        atomicStore!()( _value, v );
+    }
+
+    bool compareAndSet(long expectedValue, long newValue) shared @nogc nothrow
+    {
+        return cas(&_value, expectedValue, newValue);
+    }
+
+    long incrementAndGet() shared @nogc nothrow
+    {
+        return atomicOp!"+="(_value, 1L);
+    }
+
+    long addAndGet(long inc) shared @nogc nothrow
+    {
+        return atomicOp!"+="(_value, inc);
+    }
+
+    long getAndAdd(long inc) shared @nogc nothrow
+    {
+        auto result = atomicOp!"+="(_value, inc);
+        return result - inc;
+    }
+
+    override string toString() const
+    {
+        return (cast(shared const Sequence)this).get.to!string;
+    }
+}
+
+unittest
+{
+    auto seq = new shared Sequence();
+    assert(seq.get == Sequence.INITIAL_VALUE);
+    assert(seq.incrementAndGet() == Sequence.INITIAL_VALUE + 1);
+    assert(seq.addAndGet(5) == Sequence.INITIAL_VALUE + 6);
+    assert(seq.getAndAdd(2) == Sequence.INITIAL_VALUE + 6);
+    assert(seq.get == Sequence.INITIAL_VALUE + 8);
+    assert(seq.compareAndSet(Sequence.INITIAL_VALUE + 8, 3));
+    assert(seq.get == 3);
+    assert(!seq.compareAndSet(0, 1));
+}

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -1,0 +1,55 @@
+module disruptor.sequencer;
+
+import disruptor.sequence;
+
+interface Cursored
+{
+    long getCursor();
+}
+
+interface Sequenced
+{
+    int getBufferSize();
+    bool hasAvailableCapacity(int requiredCapacity);
+    long remainingCapacity();
+    long next();
+    long next(int n);
+    long tryNext();
+    long tryNext(int n);
+    void publish(long sequence);
+    void publish(long lo, long hi);
+}
+
+interface SequenceBarrier
+{
+    long waitFor(long sequence);
+    long getCursor();
+    bool isAlerted();
+    void alert();
+    void clearAlert();
+    void checkAlert();
+}
+
+interface DataProvider(T)
+{
+    T get(long sequence);
+}
+
+class EventPoller(T)
+{
+    // placeholder class
+}
+
+interface Sequencer : Cursored, Sequenced
+{
+    enum long INITIAL_CURSOR_VALUE = -1;
+
+    void claim(long sequence);
+    bool isAvailable(long sequence);
+    void addGatingSequences(Sequence[] gatingSequences...);
+    bool removeGatingSequence(Sequence sequence);
+    SequenceBarrier newBarrier(Sequence[] sequencesToTrack...);
+    long getMinimumSequence();
+    long getHighestPublishedSequence(long nextSequence, long availableSequence);
+    EventPoller!T newPoller(T)(DataProvider!T provider, Sequence[] gatingSequences...);
+}


### PR DESCRIPTION
## Summary
- implement `disruptor.sequence` with atomic operations mirroring Java's `Sequence`
- define `disruptor.sequencer` interface structure similar to Java `Sequencer`
- declare base package module

## Testing
- `dub build`
- `dub test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686cdedc8e14832c90e0e2beb1bcd8e8