### PR TITLE
Add additional D wait strategies

### DIFF
--- a/source/disruptor/blockingwaitstrategy.d
+++ b/source/disruptor/blockingwaitstrategy.d
@@ -1,0 +1,83 @@
+module disruptor.blockingwaitstrategy;
+
+import core.sync.mutex : Mutex;
+import core.sync.condition : Condition;
+import core.atomic : pause;
+import core.thread : Thread;
+import disruptor.sequence;
+import disruptor.sequencer : SequenceBarrier;
+import disruptor.waitstrategy : WaitStrategy;
+
+/// Blocking strategy that waits on a condition variable.
+class BlockingWaitStrategy : WaitStrategy
+{
+    private Mutex _mutex;
+    private Condition _cond;
+
+    this()
+    {
+        _mutex = new Mutex();
+        _cond = new Condition(_mutex);
+    }
+
+    override long waitFor(long sequence, shared Sequence cursor, shared Sequence dependentSequence, SequenceBarrier barrier)
+    {
+        long availableSequence;
+        if (cursor.get() < sequence)
+        {
+            _mutex.lock();
+            scope(exit) _mutex.unlock();
+            while (cursor.get() < sequence)
+            {
+                barrier.checkAlert();
+                _cond.wait();
+            }
+        }
+
+        while ((availableSequence = dependentSequence.get()) < sequence)
+        {
+            barrier.checkAlert();
+            pause();
+        }
+        return availableSequence;
+    }
+
+    override void signalAllWhenBlocking()
+    {
+        _mutex.lock();
+        _cond.notifyAll();
+        _mutex.unlock();
+    }
+}
+
+unittest
+{
+    import core.thread : Thread;
+    import core.time : msecs;
+
+    class DummySequenceBarrier : SequenceBarrier
+    {
+        override long waitFor(long sequence) { return 0; }
+        override long getCursor() { return 0; }
+        override bool isAlerted() { return false; }
+        override void alert() {}
+        override void clearAlert() {}
+        override void checkAlert() {}
+    }
+
+    auto strategy = new BlockingWaitStrategy();
+    auto cursor = new shared Sequence(0);
+    auto dependent = new shared Sequence();
+    auto barrier = new DummySequenceBarrier();
+
+    auto t = new Thread({
+        Thread.sleep(50.msecs);
+        dependent.incrementAndGet();
+        strategy.signalAllWhenBlocking();
+    });
+    t.start();
+
+    auto result = strategy.waitFor(0, cursor, dependent, barrier);
+    assert(result == 0);
+    t.join();
+}

--- a/source/disruptor/sleepingwaitstrategy.d
+++ b/source/disruptor/sleepingwaitstrategy.d
@@ -1,0 +1,102 @@
+module disruptor.sleepingwaitstrategy;
+
+import core.thread : Thread;
+import core.time : nsecs;
+import disruptor.sequence;
+import disruptor.sequencer : SequenceBarrier;
+import disruptor.waitstrategy : WaitStrategy;
+
+/// Sleeping strategy that spins, then yields, then sleeps.
+class SleepingWaitStrategy : WaitStrategy
+{
+    enum int SPIN_THRESHOLD = 100;
+    enum int DEFAULT_RETRIES = 200;
+    enum long DEFAULT_SLEEP = 100; // in nanoseconds
+
+    private int retries;
+    private long sleepTimeNs;
+
+    this()
+    {
+        this(DEFAULT_RETRIES, DEFAULT_SLEEP);
+    }
+
+    this(int retries)
+    {
+        this(retries, DEFAULT_SLEEP);
+    }
+
+    this(int retries, long sleepTimeNs)
+    {
+        this.retries = retries;
+        this.sleepTimeNs = sleepTimeNs;
+    }
+
+    override long waitFor(long sequence, shared Sequence cursor, shared Sequence dependentSequence, SequenceBarrier barrier)
+    {
+        long availableSequence;
+        int counter = retries;
+        while ((availableSequence = dependentSequence.get()) < sequence)
+        {
+            counter = applyWaitMethod(barrier, counter);
+        }
+        return availableSequence;
+    }
+
+    override void signalAllWhenBlocking()
+    {
+    }
+
+private:
+    int applyWaitMethod(SequenceBarrier barrier, int counter)
+    {
+        barrier.checkAlert();
+
+        if (counter > SPIN_THRESHOLD)
+        {
+            return counter - 1;
+        }
+        else if (counter > 0)
+        {
+            Thread.yield();
+            return counter - 1;
+        }
+        else
+        {
+            Thread.sleep(nsecs(sleepTimeNs));
+        }
+        return counter;
+    }
+}
+
+unittest
+{
+    import core.thread : Thread;
+    import core.time : msecs;
+
+    class DummySequenceBarrier : SequenceBarrier
+    {
+        override long waitFor(long sequence) { return 0; }
+        override long getCursor() { return 0; }
+        override bool isAlerted() { return false; }
+        override void alert() {}
+        override void clearAlert() {}
+        override void checkAlert() {}
+    }
+
+    auto strategy = new SleepingWaitStrategy();
+    auto cursor = new shared Sequence(0);
+    auto dependent = new shared Sequence();
+    auto barrier = new DummySequenceBarrier();
+
+    auto t = new Thread({
+        Thread.sleep(50.msecs);
+        dependent.incrementAndGet();
+        strategy.signalAllWhenBlocking();
+    });
+    t.start();
+
+    auto result = strategy.waitFor(0, cursor, dependent, barrier);
+    assert(result == 0);
+    t.join();
+}

--- a/source/disruptor/waitstrategy.d
+++ b/source/disruptor/waitstrategy.d
@@ -67,3 +67,7 @@ unittest
     assert(result == 0);
     t.join();
 }
+
+public import disruptor.blockingwaitstrategy;
+public import disruptor.sleepingwaitstrategy;
+public import disruptor.yieldingwaitstrategy;

--- a/source/disruptor/yieldingwaitstrategy.d
+++ b/source/disruptor/yieldingwaitstrategy.d
@@ -1,0 +1,75 @@
+module disruptor.yieldingwaitstrategy;
+
+import core.thread : Thread;
+import disruptor.sequence;
+import disruptor.sequencer : SequenceBarrier;
+import disruptor.waitstrategy : WaitStrategy;
+
+/// Yielding strategy that initially spins then yields the CPU.
+class YieldingWaitStrategy : WaitStrategy
+{
+    enum int SPIN_TRIES = 100;
+
+    override long waitFor(long sequence, shared Sequence cursor, shared Sequence dependentSequence, SequenceBarrier barrier)
+    {
+        long availableSequence;
+        int counter = SPIN_TRIES;
+        while ((availableSequence = dependentSequence.get()) < sequence)
+        {
+            counter = applyWaitMethod(barrier, counter);
+        }
+        return availableSequence;
+    }
+
+    override void signalAllWhenBlocking()
+    {
+    }
+
+private:
+    int applyWaitMethod(SequenceBarrier barrier, int counter)
+    {
+        barrier.checkAlert();
+
+        if (counter == 0)
+        {
+            Thread.yield();
+        }
+        else
+        {
+            return counter - 1;
+        }
+        return counter;
+    }
+}
+
+unittest
+{
+    import core.thread : Thread;
+    import core.time : msecs;
+
+    class DummySequenceBarrier : SequenceBarrier
+    {
+        override long waitFor(long sequence) { return 0; }
+        override long getCursor() { return 0; }
+        override bool isAlerted() { return false; }
+        override void alert() {}
+        override void clearAlert() {}
+        override void checkAlert() {}
+    }
+
+    auto strategy = new YieldingWaitStrategy();
+    auto cursor = new shared Sequence(0);
+    auto dependent = new shared Sequence();
+    auto barrier = new DummySequenceBarrier();
+
+    auto t = new Thread({
+        Thread.sleep(50.msecs);
+        dependent.incrementAndGet();
+        strategy.signalAllWhenBlocking();
+    });
+    t.start();
+
+    auto result = strategy.waitFor(0, cursor, dependent, barrier);
+    assert(result == 0);
+    t.join();
+}


### PR DESCRIPTION
## Summary
- implement BlockingWaitStrategy, SleepingWaitStrategy and YieldingWaitStrategy in D
- expose new strategies via `waitstrategy` module
- add unit tests mirroring Java counterparts

## Testing
- `dub build`
- `dub test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686d2ac78c38832c9df5b303831b700b