### PR TITLE
Add util module with helpers

### DIFF
--- a/source/disruptor/fixedsequencegroup.d
+++ b/source/disruptor/fixedsequencegroup.d
@@ -1,7 +1,7 @@
 module disruptor.fixedsequencegroup;
 
 import disruptor.sequence : Sequence;
-import disruptor.sequencegroup : getMinimumSequence;
+import disruptor.util : getMinimumSequence;
 
 /// Hides a group of Sequences behind a single Sequence.
 final class FixedSequenceGroup : Sequence

--- a/source/disruptor/package.d
+++ b/source/disruptor/package.d
@@ -6,3 +6,4 @@ public import disruptor.sequencegroup;
 public import disruptor.fixedsequencegroup;
 public import disruptor.sequencer;
 public import disruptor.waitstrategy;
+public import disruptor.util;

--- a/source/disruptor/sequencegroup.d
+++ b/source/disruptor/sequencegroup.d
@@ -4,18 +4,8 @@ import core.atomic;
 import core.internal.atomic : atomicLoad;
 import disruptor.sequence;
 import disruptor.sequencer : Cursored;
+import disruptor.util : getMinimumSequence;
 
-long getMinimumSequence(shared const(Sequence)[] sequences, long minimum = long.max) @nogc nothrow
-{
-    auto min = minimum;
-    foreach (s; sequences)
-    {
-        auto value = s.get();
-        if (value < min)
-            min = value;
-    }
-    return min;
-}
 
 private int countMatching(shared const(Sequence)[] values, shared const(Sequence) toMatch) @nogc nothrow
 {

--- a/source/disruptor/util.d
+++ b/source/disruptor/util.d
@@ -1,0 +1,89 @@
+module disruptor.util;
+
+import core.time : MonoTime, nsecs;
+import core.thread : Thread;
+import core.bitop : bsr;
+import disruptor.sequence : Sequence;
+
+/// Calculate the next power of two greater than or equal to x.
+int ceilingNextPowerOfTwo(int x) @nogc nothrow
+{
+    x -= 1;
+    x |= x >> 1;
+    x |= x >> 2;
+    x |= x >> 4;
+    x |= x >> 8;
+    x |= x >> 16;
+    return x + 1;
+}
+
+/// Get the minimum sequence from an array of sequences.
+long getMinimumSequence(shared const(Sequence)[] sequences) @nogc nothrow
+{
+    return getMinimumSequence(sequences, long.max);
+}
+
+/// Get the minimum sequence from an array of sequences with a default value.
+long getMinimumSequence(shared const(Sequence)[] sequences, long minimum) @nogc nothrow
+{
+    auto min = minimum;
+    foreach (s; sequences)
+    {
+        auto value = s.get();
+        if (value < min)
+            min = value;
+    }
+    return min;
+}
+
+/// Extract sequences from a list of processors providing a getSequence method.
+shared Sequence[] getSequencesFor(Processors...)(Processors processors)
+        if (Processors.length > 0 && is(typeof(processors[0].getSequence()) : Sequence))
+{
+    auto seqs = new shared Sequence[](processors.length);
+    foreach (i, p; processors)
+        seqs[i] = p.getSequence();
+    return seqs;
+}
+
+/// Integer log base 2.
+int log2(int value)
+{
+    if (value < 1)
+        throw new Exception("value must be a positive number");
+    return bsr(cast(uint) value);
+}
+
+/// Wait on the calling thread for approximately the given nanoseconds.
+long awaitNanos(Object mutex, long timeoutNanos)
+{
+    auto start = MonoTime.currTime;
+    Thread.sleep(nsecs(timeoutNanos));
+    auto waited = MonoTime.currTime - start;
+    return timeoutNanos - cast(long) waited.total!"nsecs";
+}
+
+unittest
+{
+    import std.exception : assertThrown;
+
+    assert(ceilingNextPowerOfTwo(1000) == 1024);
+    assert(ceilingNextPowerOfTwo(1024) == 1024);
+
+    auto seq1 = new shared Sequence(7);
+    auto seq2 = new shared Sequence(3);
+    auto seq3 = new shared Sequence(12);
+    shared Sequence[] seqs = [seq1, seq2, seq3];
+    assert(getMinimumSequence(cast(shared const Sequence[]) seqs) == 3);
+    assert(getMinimumSequence(cast(shared const Sequence[])[]) == long.max);
+
+    assertThrown!Exception(log2(0));
+    assertThrown!Exception(log2(-1));
+    assertThrown!Exception(log2(int.min));
+
+    assert(log2(1) == 0);
+    assert(log2(2) == 1);
+    assert(log2(3) == 1);
+    assert(log2(1024) == 10);
+    assert(log2(int.max) == 30);
+}


### PR DESCRIPTION
## Summary
- add `disruptor.util` with utility functions ported from Java
- replace local implementation in `sequencegroup` and update imports
- export utilities via package module
- add unit tests for the utility functions

## Testing
- `./gradlew test`
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_686da1469e54832c8ec101b89353b56a