### PR TITLE
Add AbstractSequencer

### DIFF
--- a/source/disruptor/package.d
+++ b/source/disruptor/package.d
@@ -4,6 +4,7 @@ module disruptor;
 public import disruptor.sequence;
 public import disruptor.sequencegroup;
 public import disruptor.fixedsequencegroup;
+public import disruptor.abstractsequencer;
 public import disruptor.sequencer;
 public import disruptor.processingsequencebarrier;
 public import disruptor.waitstrategy;


### PR DESCRIPTION
## Summary
- port AbstractSequencer from Java
- expose new module
- add tests for gating sequence management

## Testing
- `dub build`
- `dub test`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f90426688832cb75e67f9182e8ace