### PR TITLE
Align sequencer API with shared Sequence parameters

### DIFF
--- a/source/disruptor/processingsequencebarrier.d
+++ b/source/disruptor/processingsequencebarrier.d
@@ -110,12 +110,12 @@ unittest
         override void publish(long lo, long hi) {}
         override void claim(long sequence) {}
         override bool isAvailable(long sequence) { return false; }
-        override void addGatingSequences(Sequence[] gatingSequences...) {}
-        override bool removeGatingSequence(Sequence sequence) { return false; }
-        override SequenceBarrier newBarrier(Sequence[] sequencesToTrack...) { return null; }
+        override void addGatingSequences(shared Sequence[] gatingSequences...) {}
+        override bool removeGatingSequence(shared Sequence sequence) { return false; }
+        override SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...) { return null; }
         override long getMinimumSequence() { return 0; }
         override long getHighestPublishedSequence(long nextSequence, long availableSequence) { return availableSequence; }
-        EventPoller!T newPoller(T)(DataProvider!T provider, Sequence[] gatingSequences...) { return null; }
+        EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...) { return null; }
     }
 
     auto cursor = new shared Sequence(10);

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -46,10 +46,10 @@ interface Sequencer : Cursored, Sequenced
 
     void claim(long sequence);
     bool isAvailable(long sequence);
-    void addGatingSequences(Sequence[] gatingSequences...);
-    bool removeGatingSequence(Sequence sequence);
-    SequenceBarrier newBarrier(Sequence[] sequencesToTrack...);
+    void addGatingSequences(shared Sequence[] gatingSequences...);
+    bool removeGatingSequence(shared Sequence sequence);
+    SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...);
     long getMinimumSequence();
     long getHighestPublishedSequence(long nextSequence, long availableSequence);
-    EventPoller!T newPoller(T)(DataProvider!T provider, Sequence[] gatingSequences...);
+    EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...);
 }


### PR DESCRIPTION
## Summary
- accept `shared Sequence` in `Sequencer` interface
- update `AbstractSequencer` and related tests to use the new types
- fix dummy `Sequencer` in `ProcessingSequenceBarrier` tests

## Testing
- `dub build`
- `dub test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686fae1620c0832ca961813b52300bdf