### PR TITLE
Update SequenceBarrier to shared methods

### DIFF
--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -22,12 +22,12 @@ interface Sequenced
 
 interface SequenceBarrier
 {
-    long waitFor(long sequence);
-    long getCursor();
-    bool isAlerted();
-    void alert();
-    void clearAlert();
-    void checkAlert();
+    long waitFor(long sequence) shared;
+    long getCursor() shared;
+    bool isAlerted() shared;
+    void alert() shared;
+    void clearAlert() shared;
+    void checkAlert() shared;
 }
 
 interface DataProvider(T)


### PR DESCRIPTION
## Summary
- mark SequenceBarrier methods as `shared`
- update ProcessingSequenceBarrier and wait strategy implementations
- adjust unittests to use shared casts

## Testing
- `./gradlew test`
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_686fae175688832ca624085a4d3e9075