### PR TITLE
Fix shared signatures for cursor helpers

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -30,7 +30,7 @@ public:
     }
 
     /// Return the current cursor value.
-    override long getCursor() @nogc nothrow
+    override long getCursor() shared @nogc nothrow
     {
         return cursor.get();
     }
@@ -44,7 +44,7 @@ public:
     /// Add gating sequences to be tracked by this sequencer.
     override void addGatingSequences(shared Sequence[] sequencesToAdd...)
     {
-        addSequences(&gatingSequences, cast(Cursored)this, sequencesToAdd);
+        addSequences(&gatingSequences, cast(shared Cursored)this, sequencesToAdd);
     }
 
     /// Remove a gating sequence.
@@ -121,8 +121,8 @@ unittest
     auto g2 = new shared Sequence();
 
     seq.addGatingSequences(g1, g2);
-    assert(g1.get == seq.getCursor());
-    assert(g2.get == seq.getCursor());
+    assert(g1.get == (cast(shared)seq).getCursor());
+    assert(g2.get == (cast(shared)seq).getCursor());
 
     seq.setCursor(7);
 

--- a/source/disruptor/processingsequencebarrier.d
+++ b/source/disruptor/processingsequencebarrier.d
@@ -98,7 +98,7 @@ unittest
     {
         shared Sequence cursor;
         this(shared Sequence cursor) { this.cursor = cursor; }
-        override long getCursor() { return cursor.get(); }
+        override long getCursor() shared { return cursor.get(); }
         override int getBufferSize() { return 0; }
         override bool hasAvailableCapacity(int requiredCapacity) { return false; }
         override long remainingCapacity() { return 0; }

--- a/source/disruptor/sequencegroup.d
+++ b/source/disruptor/sequencegroup.d
@@ -18,7 +18,7 @@ private int countMatching(shared const(Sequence)[] values, shared const(Sequence
     return count;
 }
 
-void addSequences(shared Sequence[]* field, Cursored cursor, shared Sequence[] sequencesToAdd...)
+void addSequences(shared Sequence[]* field, shared Cursored cursor, shared Sequence[] sequencesToAdd...)
 {
     long cursorSequence;
     shared Sequence[] updated;
@@ -117,7 +117,7 @@ public:
         return cast(int) atomicLoad!(MemoryOrder.acq)(&sequences).length;
     }
 
-    void addWhileRunning(Cursored cursor, shared Sequence sequence) shared
+    void addWhileRunning(shared Cursored cursor, shared Sequence sequence) shared
     {
         addSequences(&sequences, cursor, sequence);
     }
@@ -171,7 +171,7 @@ unittest
     class StubCursor : Cursored
     {
         long cursor = 0;
-        override long getCursor() { return cursor; }
+        override long getCursor() shared { return cursor; }
         void advance(long value) { cursor += value; }
     }
 
@@ -180,12 +180,12 @@ unittest
 
     cursor.advance(5);
     auto seq1 = new shared Sequence();
-    group.addWhileRunning(cursor, seq1);
+    group.addWhileRunning(cast(shared Cursored)cursor, seq1);
     assert(seq1.get == 5);
 
     cursor.advance(3);
     auto seq2 = new shared Sequence();
-    group.addWhileRunning(cursor, seq2);
+    group.addWhileRunning(cast(shared Cursored)cursor, seq2);
     assert(seq2.get == 8);
 
     assert(group.size == 2);

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -4,7 +4,7 @@ import disruptor.sequence;
 
 interface Cursored
 {
-    long getCursor();
+    long getCursor() shared;
 }
 
 interface Sequenced


### PR DESCRIPTION
## Summary
- mark `Cursored.getCursor` as `shared`
- require a `shared Cursored` in `addSequences` and related helper
- update implementations and unit tests for new shared methods

## Testing
- `./gradlew test`
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_686fbd5a58d0832c8b1b19b1189a640b