### PR TITLE
Fix WaitStrategy sharing in D modules

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -12,12 +12,12 @@ abstract class AbstractSequencer : Sequencer
 {
 protected:
     int bufferSize;
-    WaitStrategy waitStrategy;
+    shared WaitStrategy waitStrategy;
     shared Sequence cursor;
     align(16) shared Sequence[] gatingSequences = [];
 
 public:
-    this(int bufferSize, WaitStrategy waitStrategy)
+    this(int bufferSize, shared WaitStrategy waitStrategy)
     {
         if (bufferSize < 1)
             throw new Exception("bufferSize must not be less than 1");
@@ -90,7 +90,7 @@ unittest
     // Minimal implementation for testing.
     class DummySequencer : AbstractSequencer
     {
-        this(int size, WaitStrategy strategy)
+        this(int size, shared WaitStrategy strategy)
         {
             super(size, strategy);
         }
@@ -114,15 +114,15 @@ unittest
         EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...) { return null; }
     }
 
-    auto strategy = new SleepingWaitStrategy();
+    auto strategy = new shared SleepingWaitStrategy();
     auto seq = new DummySequencer(8, strategy);
 
     auto g1 = new shared Sequence();
     auto g2 = new shared Sequence();
 
     seq.addGatingSequences(g1, g2);
-    assert(g1.get == (cast(shared)seq).getCursor());
-    assert(g2.get == (cast(shared)seq).getCursor());
+    assert(g1.get == seq.cursor.get());
+    assert(g2.get == seq.cursor.get());
 
     seq.setCursor(7);
 

--- a/source/disruptor/blockingwaitstrategy.d
+++ b/source/disruptor/blockingwaitstrategy.d
@@ -14,10 +14,10 @@ class BlockingWaitStrategy : WaitStrategy
     private Mutex _mutex;
     private Condition _cond;
 
-    this()
+    this() shared
     {
-        _mutex = new Mutex();
-        _cond = new Condition(_mutex);
+        _mutex = new shared Mutex();
+        _cond = new shared Condition(_mutex);
     }
 
     override long waitFor(long sequence, shared Sequence cursor, shared Sequence dependentSequence, shared SequenceBarrier barrier) shared
@@ -65,19 +65,19 @@ unittest
         override void checkAlert() shared {}
     }
 
-    auto strategy = new BlockingWaitStrategy();
+    auto strategy = new shared BlockingWaitStrategy();
     auto cursor = new shared Sequence(0);
     auto dependent = new shared Sequence();
-    auto barrier = new DummySequenceBarrier();
+    auto barrier = new shared DummySequenceBarrier();
 
     auto t = new Thread({
         Thread.sleep(50.msecs);
         dependent.incrementAndGet();
-        (cast(shared BlockingWaitStrategy)strategy).signalAllWhenBlocking();
+        strategy.signalAllWhenBlocking();
     });
     t.start();
 
-    auto result = (cast(shared BlockingWaitStrategy)strategy).waitFor(0, cursor, dependent, cast(shared SequenceBarrier)barrier);
+    auto result = strategy.waitFor(0, cursor, dependent, barrier);
     assert(result == 0);
     t.join();
 }

--- a/source/disruptor/processingsequencebarrier.d
+++ b/source/disruptor/processingsequencebarrier.d
@@ -19,13 +19,13 @@ class ProcessingSequenceBarrier : SequenceBarrier
 {
 private:
     Sequencer _sequencer;
-    WaitStrategy _waitStrategy;
+    shared WaitStrategy _waitStrategy;
     shared Sequence _cursorSequence;
     shared Sequence _dependentSequence;
     bool _alerted = false;
 
 public:
-    this(Sequencer sequencer, WaitStrategy waitStrategy,
+    this(Sequencer sequencer, shared WaitStrategy waitStrategy,
             shared Sequence cursorSequence, shared Sequence[] dependentSequences = [])
     {
         this._sequencer = sequencer;
@@ -120,7 +120,7 @@ unittest
 
     auto cursor = new shared Sequence(10);
     auto sequencer = new DummySequencer(cursor);
-    auto waitStrategy = new BusySpinWaitStrategy();
+    auto waitStrategy = new shared BusySpinWaitStrategy();
 
     auto dep1 = new shared Sequence(10);
     auto dep2 = new shared Sequence(9);

--- a/source/disruptor/sleepingwaitstrategy.d
+++ b/source/disruptor/sleepingwaitstrategy.d
@@ -16,17 +16,17 @@ class SleepingWaitStrategy : WaitStrategy
     private int retries;
     private long sleepTimeNs;
 
-    this()
+    this() shared
     {
         this(DEFAULT_RETRIES, DEFAULT_SLEEP);
     }
 
-    this(int retries)
+    this(int retries) shared
     {
         this(retries, DEFAULT_SLEEP);
     }
 
-    this(int retries, long sleepTimeNs)
+    this(int retries, long sleepTimeNs) shared
     {
         this.retries = retries;
         this.sleepTimeNs = sleepTimeNs;
@@ -84,19 +84,19 @@ unittest
         override void checkAlert() shared {}
     }
 
-    auto strategy = new SleepingWaitStrategy();
+    auto strategy = new shared SleepingWaitStrategy();
     auto cursor = new shared Sequence(0);
     auto dependent = new shared Sequence();
-    auto barrier = new DummySequenceBarrier();
+    auto barrier = new shared DummySequenceBarrier();
 
     auto t = new Thread({
         Thread.sleep(50.msecs);
         dependent.incrementAndGet();
-        (cast(shared SleepingWaitStrategy)strategy).signalAllWhenBlocking();
+        strategy.signalAllWhenBlocking();
     });
     t.start();
 
-    auto result = (cast(shared SleepingWaitStrategy)strategy).waitFor(0, cursor, dependent, cast(shared SequenceBarrier)barrier);
+    auto result = strategy.waitFor(0, cursor, dependent, barrier);
     assert(result == 0);
     t.join();
 }


### PR DESCRIPTION
## Summary
- make `SleepingWaitStrategy` constructors shared and adjust unit tests
- make `BlockingWaitStrategy` constructor shared and adjust unit tests
- update sequencer test to use shared wait strategy without casts
- clean up casts in ProcessingSequenceBarrier tests

## Testing
- `dub build && dub test`
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_686fca3b29ec832c869491759203627b