### PR TITLE
Add MultiProducerSequencer in D

### DIFF
--- a/source/disruptor/insufficientcapacityexception.d
+++ b/source/disruptor/insufficientcapacityexception.d
@@ -1,0 +1,18 @@
+module disruptor.insufficientcapacityexception;
+
+/// Exception thrown when the ring buffer lacks capacity.
+class InsufficientCapacityException : Exception
+{
+    static __gshared InsufficientCapacityException INSTANCE;
+
+    this(string msg = "Insufficient capacity", string file = __FILE__, size_t line = __LINE__)
+    {
+        super(msg, file, line);
+    }
+
+}
+
+shared static this()
+{
+    InsufficientCapacityException.INSTANCE = new InsufficientCapacityException();
+}

--- a/source/disruptor/multiproducersequencer.d
+++ b/source/disruptor/multiproducersequencer.d
@@ -1,0 +1,194 @@
+module disruptor.multiproducersequencer;
+
+import core.atomic;
+import core.thread : Thread;
+import disruptor.sequence : Sequence;
+import disruptor.waitstrategy : WaitStrategy;
+import disruptor.sequencer : Sequencer;
+import disruptor.abstractsequencer : AbstractSequencer;
+import disruptor.util : utilGetMinimumSequence = getMinimumSequence, log2;
+import disruptor.insufficientcapacityexception : InsufficientCapacityException;
+
+/// Coordinator for claiming sequences suitable for multiple publisher threads.
+final class MultiProducerSequencer : AbstractSequencer
+{
+private:
+    shared Sequence gatingSequenceCache;
+    shared int[] availableBuffer;
+    int indexMask;
+    int indexShift;
+
+public:
+    this(int bufferSize, shared WaitStrategy waitStrategy)
+    {
+        super(bufferSize, waitStrategy);
+        gatingSequenceCache = new shared Sequence(Sequencer.INITIAL_CURSOR_VALUE);
+        availableBuffer = new shared int[](bufferSize);
+        foreach (i; 0 .. bufferSize)
+            availableBuffer[i] = -1;
+        indexMask = bufferSize - 1;
+        indexShift = log2(bufferSize);
+    }
+
+    override bool hasAvailableCapacity(int requiredCapacity)
+    {
+        return hasAvailableCapacity(gatingSequences, requiredCapacity, cursor.get());
+    }
+
+private:
+    bool hasAvailableCapacity(shared Sequence[] gatingSequences, int requiredCapacity, long cursorValue)
+    {
+        long wrapPoint = (cursorValue + requiredCapacity) - bufferSize;
+        long cachedGatingSequence = gatingSequenceCache.get();
+
+        if (wrapPoint > cachedGatingSequence || cachedGatingSequence > cursorValue)
+        {
+            long minSequence = utilGetMinimumSequence(cast(shared const Sequence[]) gatingSequences, cursorValue);
+            gatingSequenceCache.set(minSequence);
+
+            if (wrapPoint > minSequence)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+public:
+    override void claim(long sequence)
+    {
+        cursor.set(sequence);
+    }
+
+    override long next()
+    {
+        return next(1);
+    }
+
+    override long next(int n)
+    {
+        if (n < 1 || n > bufferSize)
+            throw new Exception("n must be > 0 and < bufferSize", __FILE__, __LINE__);
+
+        long current = cursor.getAndAdd(n);
+        long nextSequence = current + n;
+        long wrapPoint = nextSequence - bufferSize;
+        long cachedGatingSequence = gatingSequenceCache.get();
+
+        if (wrapPoint > cachedGatingSequence || cachedGatingSequence > current)
+        {
+            long gatingSequence;
+            while (wrapPoint > (gatingSequence = utilGetMinimumSequence(cast(shared const Sequence[]) gatingSequences, current)))
+            {
+                Thread.yield();
+            }
+            gatingSequenceCache.set(gatingSequence);
+        }
+        return nextSequence;
+    }
+
+    override long tryNext()
+    {
+        return tryNext(1);
+    }
+
+    override long tryNext(int n)
+    {
+        if (n < 1)
+            throw new Exception("n must be > 0", __FILE__, __LINE__);
+
+        long current;
+        long next;
+        do
+        {
+            current = cursor.get();
+            next = current + n;
+
+            if (!hasAvailableCapacity(gatingSequences, n, current))
+                throw InsufficientCapacityException.INSTANCE;
+        }
+        while (!cursor.compareAndSet(current, next));
+
+        return next;
+    }
+
+    override long remainingCapacity()
+    {
+        long consumed = utilGetMinimumSequence(cast(shared const Sequence[]) gatingSequences, cursor.get());
+        long produced = cursor.get();
+        return bufferSize - (produced - consumed);
+    }
+
+    override void publish(long sequence)
+    {
+        setAvailable(sequence);
+        waitStrategy.signalAllWhenBlocking();
+    }
+
+    override void publish(long lo, long hi)
+    {
+        for (long l = lo; l <= hi; l++)
+        {
+            setAvailable(l);
+        }
+        waitStrategy.signalAllWhenBlocking();
+    }
+
+private:
+    void setAvailable(long sequence)
+    {
+        setAvailableBufferValue(calculateIndex(sequence), calculateAvailabilityFlag(sequence));
+    }
+
+    void setAvailableBufferValue(int index, int flag)
+    {
+        atomicStore!(MemoryOrder.rel)(availableBuffer[index], flag);
+    }
+
+public:
+    override bool isAvailable(long sequence)
+    {
+        int index = calculateIndex(sequence);
+        int flag = calculateAvailabilityFlag(sequence);
+        return atomicLoad!(MemoryOrder.acq)(availableBuffer[index]) == flag;
+    }
+
+    override long getHighestPublishedSequence(long lowerBound, long availableSequence)
+    {
+        for (long sequence = lowerBound; sequence <= availableSequence; sequence++)
+        {
+            if (!isAvailable(sequence))
+                return sequence - 1;
+        }
+        return availableSequence;
+    }
+
+private:
+    int calculateAvailabilityFlag(long sequence)
+    {
+        return cast(int)(sequence >>> indexShift);
+    }
+
+    int calculateIndex(long sequence)
+    {
+        return cast(int)sequence & indexMask;
+    }
+}
+
+unittest
+{
+    import disruptor.blockingwaitstrategy : BlockingWaitStrategy;
+
+    auto sequencer = new MultiProducerSequencer(1024, new shared BlockingWaitStrategy());
+
+    sequencer.publish(3);
+    sequencer.publish(5);
+
+    assert(!sequencer.isAvailable(0));
+    assert(!sequencer.isAvailable(1));
+    assert(!sequencer.isAvailable(2));
+    assert(sequencer.isAvailable(3));
+    assert(!sequencer.isAvailable(4));
+    assert(sequencer.isAvailable(5));
+    assert(!sequencer.isAvailable(6));
+}

--- a/source/disruptor/package.d
+++ b/source/disruptor/package.d
@@ -9,3 +9,5 @@ public import disruptor.sequencer;
 public import disruptor.processingsequencebarrier;
 public import disruptor.waitstrategy;
 public import disruptor.util;
+public import disruptor.insufficientcapacityexception;
+public import disruptor.multiproducersequencer;


### PR DESCRIPTION
## Summary
- port `MultiProducerSequencer` from Java to D
- add accompanying unittests translated from Java tests
- expose new modules from `package.d`
- implement `InsufficientCapacityException` needed by the sequencer

## Testing
- `dub build`
- `dub test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686fd3adcaf4832cb74f6baa752c032d