### PR TITLE
Fix shared allocations in unit tests

### DIFF
--- a/source/disruptor/sequencegroup.d
+++ b/source/disruptor/sequencegroup.d
@@ -166,26 +166,27 @@ unittest
 
 unittest
 {
+    import core.atomic : atomicOp;
     // addWhileRunning should set new sequences to the cursor value at the time
     // they are added.
     class StubCursor : Cursored
     {
         long cursor = 0;
         override long getCursor() shared { return cursor; }
-        void advance(long value) { cursor += value; }
+        void advance(long value) shared { atomicOp!("+=")(cursor, value); }
     }
 
-    auto cursor = new StubCursor();
+    auto cursor = new shared StubCursor();
     auto group = new shared SequenceGroup();
 
     cursor.advance(5);
     auto seq1 = new shared Sequence();
-    group.addWhileRunning(cast(shared Cursored)cursor, seq1);
+    group.addWhileRunning(cursor, seq1);
     assert(seq1.get == 5);
 
     cursor.advance(3);
     auto seq2 = new shared Sequence();
-    group.addWhileRunning(cast(shared Cursored)cursor, seq2);
+    group.addWhileRunning(cursor, seq2);
     assert(seq2.get == 8);
 
     assert(group.size == 2);

--- a/source/disruptor/waitstrategy.d
+++ b/source/disruptor/waitstrategy.d
@@ -50,20 +50,20 @@ unittest
         override void checkAlert() shared {}
     }
 
-    auto strategy = new BusySpinWaitStrategy();
+    auto strategy = new shared BusySpinWaitStrategy();
     auto cursor = new shared Sequence(0); // unused by strategy
     auto dependent = new shared Sequence(); // starts at INITIAL_VALUE (-1)
-    auto barrier = new DummySequenceBarrier();
+    auto barrier = new shared DummySequenceBarrier();
 
     auto t = new Thread({
         Thread.sleep(50.msecs);
         dependent.incrementAndGet();
-        (cast(shared BusySpinWaitStrategy)strategy).signalAllWhenBlocking();
+        strategy.signalAllWhenBlocking();
     });
     t.start();
 
     // Wait for sequence 0
-    auto result = (cast(shared BusySpinWaitStrategy)strategy).waitFor(0, cursor, dependent, cast(shared SequenceBarrier)barrier);
+    auto result = strategy.waitFor(0, cursor, dependent, barrier);
     assert(result == 0);
     t.join();
 }

--- a/source/disruptor/yieldingwaitstrategy.d
+++ b/source/disruptor/yieldingwaitstrategy.d
@@ -57,19 +57,19 @@ unittest
         override void checkAlert() shared {}
     }
 
-    auto strategy = new YieldingWaitStrategy();
+    auto strategy = new shared YieldingWaitStrategy();
     auto cursor = new shared Sequence(0);
     auto dependent = new shared Sequence();
-    auto barrier = new DummySequenceBarrier();
+    auto barrier = new shared DummySequenceBarrier();
 
     auto t = new Thread({
         Thread.sleep(50.msecs);
         dependent.incrementAndGet();
-        (cast(shared YieldingWaitStrategy)strategy).signalAllWhenBlocking();
+        strategy.signalAllWhenBlocking();
     });
     t.start();
 
-    auto result = (cast(shared YieldingWaitStrategy)strategy).waitFor(0, cursor, dependent, cast(shared SequenceBarrier)barrier);
+    auto result = strategy.waitFor(0, cursor, dependent, barrier);
     assert(result == 0);
     t.join();
 }


### PR DESCRIPTION
## Summary
- construct BusySpinWaitStrategy and DummySequenceBarrier using `new shared`
- create shared ProcessingSequenceBarrier in tests
- build SequenceGroup test cursor as `shared`
- update YieldingWaitStrategy test to avoid casts

## Testing
- `dub test`

------
https://chatgpt.com/codex/tasks/task_e_687048661a18832cba92d873f56651d0