### PR TITLE
Fix shared types in BlockingWaitStrategy

### DIFF
--- a/source/disruptor/blockingwaitstrategy.d
+++ b/source/disruptor/blockingwaitstrategy.d
@@ -11,8 +11,8 @@ import disruptor.waitstrategy : WaitStrategy;
 /// Blocking strategy that waits on a condition variable.
 class BlockingWaitStrategy : WaitStrategy
 {
-    private Mutex _mutex;
-    private Condition _cond;
+    private shared Mutex _mutex;
+    private shared Condition _cond;
 
     this() shared
     {


### PR DESCRIPTION
## Summary
- make mutex and condition shared in `BlockingWaitStrategy`

## Testing
- `dub build -q`
- `dub test -q`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6870fe6d4458832c80ac1a2edd075a20