### PR TITLE
Fix shared Sequencer usage

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -60,14 +60,14 @@ public:
     }
 
     /// Create a new sequence barrier tracking the given sequences.
-    override SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...)
+    override SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...) shared
     {
         return new ProcessingSequenceBarrier(this, waitStrategy, cursor, sequencesToTrack);
     }
 
     // Abstract methods to be provided by subclasses.
     abstract override void claim(long sequence);
-    abstract override bool isAvailable(long sequence);
+    abstract override bool isAvailable(long sequence) shared;
     abstract override bool hasAvailableCapacity(int requiredCapacity);
     abstract override long remainingCapacity();
     abstract override long next();
@@ -76,7 +76,7 @@ public:
     abstract override long tryNext(int n);
     abstract override void publish(long sequence);
     abstract override void publish(long lo, long hi);
-    abstract override long getHighestPublishedSequence(long nextSequence, long availableSequence);
+    abstract override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared;
     EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...)
     {
         return null;
@@ -101,7 +101,7 @@ unittest
         }
 
         override void claim(long sequence) {}
-        override bool isAvailable(long sequence) { return true; }
+        override bool isAvailable(long sequence) shared { return true; }
         override bool hasAvailableCapacity(int requiredCapacity) { return true; }
         override long remainingCapacity() { return 0; }
         override long next() { return 0; }
@@ -110,7 +110,7 @@ unittest
         override long tryNext(int n) { return 0; }
         override void publish(long sequence) {}
         override void publish(long lo, long hi) {}
-        override long getHighestPublishedSequence(long nextSequence, long availableSequence) { return availableSequence; }
+        override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared { return availableSequence; }
         EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...) { return null; }
     }
 

--- a/source/disruptor/multiproducersequencer.d
+++ b/source/disruptor/multiproducersequencer.d
@@ -146,14 +146,14 @@ private:
     }
 
 public:
-    override bool isAvailable(long sequence)
+    override bool isAvailable(long sequence) shared
     {
-        int index = calculateIndex(sequence);
-        int flag = calculateAvailabilityFlag(sequence);
+        int index = (cast(MultiProducerSequencer)this).calculateIndex(sequence);
+        int flag = (cast(MultiProducerSequencer)this).calculateAvailabilityFlag(sequence);
         return atomicLoad!(MemoryOrder.acq)(availableBuffer[index]) == flag;
     }
 
-    override long getHighestPublishedSequence(long lowerBound, long availableSequence)
+    override long getHighestPublishedSequence(long lowerBound, long availableSequence) shared
     {
         for (long sequence = lowerBound; sequence <= availableSequence; sequence++)
         {
@@ -184,11 +184,12 @@ unittest
     sequencer.publish(3);
     sequencer.publish(5);
 
-    assert(!sequencer.isAvailable(0));
-    assert(!sequencer.isAvailable(1));
-    assert(!sequencer.isAvailable(2));
-    assert(sequencer.isAvailable(3));
-    assert(!sequencer.isAvailable(4));
-    assert(sequencer.isAvailable(5));
-    assert(!sequencer.isAvailable(6));
+    auto sharedSeq = cast(shared MultiProducerSequencer)sequencer;
+    assert(!sharedSeq.isAvailable(0));
+    assert(!sharedSeq.isAvailable(1));
+    assert(!sharedSeq.isAvailable(2));
+    assert(sharedSeq.isAvailable(3));
+    assert(!sharedSeq.isAvailable(4));
+    assert(sharedSeq.isAvailable(5));
+    assert(!sharedSeq.isAvailable(6));
 }

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -45,11 +45,11 @@ interface Sequencer : Cursored, Sequenced
     enum long INITIAL_CURSOR_VALUE = -1;
 
     void claim(long sequence);
-    bool isAvailable(long sequence);
+    bool isAvailable(long sequence) shared;
     void addGatingSequences(shared Sequence[] gatingSequences...);
     bool removeGatingSequence(shared Sequence sequence);
-    SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...);
+    SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...) shared;
     long getMinimumSequence();
-    long getHighestPublishedSequence(long nextSequence, long availableSequence);
+    long getHighestPublishedSequence(long nextSequence, long availableSequence) shared;
     EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...);
 }

--- a/source/disruptor/singleproducersequencer.d
+++ b/source/disruptor/singleproducersequencer.d
@@ -125,13 +125,13 @@ public:
         publish(hi);
     }
 
-    override bool isAvailable(long sequence)
+    override bool isAvailable(long sequence) shared
     {
         long currentSequence = cursor.get();
         return sequence <= currentSequence && sequence > currentSequence - bufferSize;
     }
 
-    override long getHighestPublishedSequence(long lowerBound, long availableSequence)
+    override long getHighestPublishedSequence(long lowerBound, long availableSequence) shared
     {
         return availableSequence;
     }


### PR DESCRIPTION
## Summary
- allow ProcessingSequenceBarrier to store a shared `Sequencer`
- mark Sequencer methods used from shared code as `shared`
- update sequencer implementations to match new signatures
- remove casts in ProcessingSequenceBarrier
- refine constructor usage for shared Sequencer
- mark `newBarrier` as `shared` to avoid casting `this`

## Testing
- `./gradlew test`
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_6870fe6e3a0c832ca18e9dfad9276a04