### PR TITLE
Update gating sequence methods to be shared

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -42,13 +42,13 @@ public:
     }
 
     /// Add gating sequences to be tracked by this sequencer.
-    override void addGatingSequences(shared Sequence[] sequencesToAdd...)
+    override void addGatingSequences(shared Sequence[] sequencesToAdd...) shared
     {
-        addSequences(&gatingSequences, cast(shared Cursored)this, sequencesToAdd);
+        addSequences(&gatingSequences, this, sequencesToAdd);
     }
 
     /// Remove a gating sequence.
-    override bool removeGatingSequence(shared Sequence sequence)
+    override bool removeGatingSequence(shared Sequence sequence) shared
     {
         return removeSequence(&gatingSequences, sequence);
     }
@@ -120,7 +120,7 @@ unittest
     auto g1 = new shared Sequence();
     auto g2 = new shared Sequence();
 
-    seq.addGatingSequences(g1, g2);
+    (cast(shared DummySequencer)seq).addGatingSequences(g1, g2);
     assert(g1.get == seq.cursor.get());
     assert(g2.get == seq.cursor.get());
 
@@ -133,7 +133,7 @@ unittest
     g2.set(7);
     assert(seq.getMinimumSequence() == 5);
 
-    assert(seq.removeGatingSequence(g1));
-    assert(!seq.removeGatingSequence(g1));
+    assert((cast(shared DummySequencer)seq).removeGatingSequence(g1));
+    assert(!(cast(shared DummySequencer)seq).removeGatingSequence(g1));
     assert(seq.getMinimumSequence() == 7);
 }

--- a/source/disruptor/processingsequencebarrier.d
+++ b/source/disruptor/processingsequencebarrier.d
@@ -127,8 +127,8 @@ unittest
         override void publish(long lo, long hi) {}
         override void claim(long sequence) {}
         override bool isAvailable(long sequence) shared { return false; }
-        override void addGatingSequences(shared Sequence[] gatingSequences...) {}
-        override bool removeGatingSequence(shared Sequence sequence) { return false; }
+        override void addGatingSequences(shared Sequence[] gatingSequences...) shared {}
+        override bool removeGatingSequence(shared Sequence sequence) shared { return false; }
         override SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...) shared { return null; }
         override long getMinimumSequence() { return 0; }
         override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared { return availableSequence; }

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -46,8 +46,8 @@ interface Sequencer : Cursored, Sequenced
 
     void claim(long sequence);
     bool isAvailable(long sequence) shared;
-    void addGatingSequences(shared Sequence[] gatingSequences...);
-    bool removeGatingSequence(shared Sequence sequence);
+    void addGatingSequences(shared Sequence[] gatingSequences...) shared;
+    bool removeGatingSequence(shared Sequence sequence) shared;
     SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...) shared;
     long getMinimumSequence();
     long getHighestPublishedSequence(long nextSequence, long availableSequence) shared;


### PR DESCRIPTION
## Summary
- mark `addGatingSequences` and `removeGatingSequence` as `shared` in `Sequencer`
- update implementations and dummy sequencer
- adjust unit tests to call shared methods

## Testing
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_6871151bb77c832c871b5f40f68b6e58