### PR TITLE
Update toString in FixedSequenceGroup

### DIFF
--- a/source/disruptor/fixedsequencegroup.d
+++ b/source/disruptor/fixedsequencegroup.d
@@ -43,7 +43,7 @@ public:
         assert(0, "unsupported");
     }
 
-    override string toString() const
+    override string toString() const shared
     {
         import std.array : appender;
         import std.conv : to;
@@ -54,7 +54,7 @@ public:
         {
             if (i != 0)
                 app.put(", ");
-            app.put((cast(shared const Sequence) seq).get.to!string);
+            app.put(seq.get.to!string);
         }
         app.put("]");
         return app.data;

--- a/source/disruptor/sequence.d
+++ b/source/disruptor/sequence.d
@@ -57,9 +57,9 @@ public:
         return result - inc;
     }
 
-    override string toString() const
+    string toString() const shared
     {
-        return (cast(shared const Sequence)this).get.to!string;
+        return get.to!string;
     }
 }
 


### PR DESCRIPTION
## Summary
- make `FixedSequenceGroup.toString` operate on shared instances
- expose `Sequence.toString` for shared access

## Testing
- `./gradlew test --no-daemon`
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_6871152cca6c832ca9cd0f36b2f888af