### PR TITLE
Align newBarrier with shared return type

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -60,9 +60,9 @@ public:
     }
 
     /// Create a new sequence barrier tracking the given sequences.
-    override SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...) shared
+    override shared(SequenceBarrier) newBarrier(shared Sequence[] sequencesToTrack...) shared
     {
-        return new ProcessingSequenceBarrier(this, waitStrategy, cursor, sequencesToTrack);
+        return new shared ProcessingSequenceBarrier(this, waitStrategy, cursor, sequencesToTrack);
     }
 
     // Abstract methods to be provided by subclasses.

--- a/source/disruptor/processingsequencebarrier.d
+++ b/source/disruptor/processingsequencebarrier.d
@@ -129,7 +129,7 @@ unittest
         override bool isAvailable(long sequence) shared { return false; }
         override void addGatingSequences(shared Sequence[] gatingSequences...) {}
         override bool removeGatingSequence(shared Sequence sequence) { return false; }
-        override SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...) shared { return null; }
+        override shared(SequenceBarrier) newBarrier(shared Sequence[] sequencesToTrack...) shared { return null; }
         override long getMinimumSequence() { return 0; }
         override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared { return availableSequence; }
         EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...) { return null; }

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -48,7 +48,7 @@ interface Sequencer : Cursored, Sequenced
     bool isAvailable(long sequence) shared;
     void addGatingSequences(shared Sequence[] gatingSequences...);
     bool removeGatingSequence(shared Sequence sequence);
-    SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...) shared;
+    shared(SequenceBarrier) newBarrier(shared Sequence[] sequencesToTrack...) shared;
     long getMinimumSequence();
     long getHighestPublishedSequence(long nextSequence, long availableSequence) shared;
     EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...);


### PR DESCRIPTION
## Summary
- change `Sequencer.newBarrier` to return a `shared SequenceBarrier`
- adjust `AbstractSequencer` to build a `shared ProcessingSequenceBarrier`
- update processing sequence barrier tests

## Testing
- `./gradlew test --no-daemon`
- `dub build`
- `dub test`

------
https://chatgpt.com/codex/tasks/task_e_6871153aa850832c85fc2f7f0c81fe1a