### PR TITLE
Use scoped const sequences in utility APIs

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -56,7 +56,7 @@ public:
     /// Get the minimum sequence seen by gating sequences.
     override long getMinimumSequence() @nogc nothrow
     {
-        return utilGetMinimumSequence(cast(shared const Sequence[]) gatingSequences, cursor.get());
+        return utilGetMinimumSequence(gatingSequences, cursor.get());
     }
 
     /// Create a new sequence barrier tracking the given sequences.

--- a/source/disruptor/fixedsequencegroup.d
+++ b/source/disruptor/fixedsequencegroup.d
@@ -20,7 +20,7 @@ public:
     override long get() const shared @nogc nothrow
     {
         // The array is immutable so no atomic load needed
-        return getMinimumSequence(cast(shared const Sequence[]) sequences);
+        return getMinimumSequence(sequences);
     }
 
     override void set(long value) shared @nogc nothrow

--- a/source/disruptor/multiproducersequencer.d
+++ b/source/disruptor/multiproducersequencer.d
@@ -43,7 +43,7 @@ private:
 
         if (wrapPoint > cachedGatingSequence || cachedGatingSequence > cursorValue)
         {
-            long minSequence = utilGetMinimumSequence(cast(shared const Sequence[]) gatingSequences, cursorValue);
+            long minSequence = utilGetMinimumSequence(gatingSequences, cursorValue);
             gatingSequenceCache.set(minSequence);
 
             if (wrapPoint > minSequence)
@@ -78,7 +78,7 @@ public:
         if (wrapPoint > cachedGatingSequence || cachedGatingSequence > current)
         {
             long gatingSequence;
-            while (wrapPoint > (gatingSequence = utilGetMinimumSequence(cast(shared const Sequence[]) gatingSequences, current)))
+            while (wrapPoint > (gatingSequence = utilGetMinimumSequence(gatingSequences, current)))
             {
                 Thread.yield();
             }
@@ -114,7 +114,7 @@ public:
 
     override long remainingCapacity()
     {
-        long consumed = utilGetMinimumSequence(cast(shared const Sequence[]) gatingSequences, cursor.get());
+        long consumed = utilGetMinimumSequence(gatingSequences, cursor.get());
         long produced = cursor.get();
         return bufferSize - (produced - consumed);
     }

--- a/source/disruptor/sequencegroup.d
+++ b/source/disruptor/sequencegroup.d
@@ -7,7 +7,7 @@ import disruptor.sequencer : Cursored;
 import disruptor.util : getMinimumSequence;
 
 
-private int countMatching(shared const(Sequence)[] values, shared const(Sequence) toMatch) @nogc nothrow
+private int countMatching(scope const(shared Sequence)[] values, const(shared Sequence) toMatch) @nogc nothrow
 {
     int count = 0;
     foreach (v; values)

--- a/source/disruptor/singleproducersequencer.d
+++ b/source/disruptor/singleproducersequencer.d
@@ -40,7 +40,7 @@ private:
                 cursor.setVolatile(nextValue); // StoreLoad fence
             }
 
-            long minSequence = utilGetMinimumSequence(cast(shared const Sequence[]) gatingSequences, nextValue);
+            long minSequence = utilGetMinimumSequence(gatingSequences, nextValue);
             this.cachedValue = minSequence;
 
             if (wrapPoint > minSequence)
@@ -73,7 +73,7 @@ public:
             cursor.setVolatile(nextValue); // StoreLoad fence
 
             long minSequence;
-            while (wrapPoint > (minSequence = utilGetMinimumSequence(cast(shared const Sequence[]) gatingSequences, nextValue)))
+            while (wrapPoint > (minSequence = utilGetMinimumSequence(gatingSequences, nextValue)))
             {
                 Thread.yield();
             }
@@ -104,7 +104,7 @@ public:
     override long remainingCapacity()
     {
         long nextValue = this.nextValue;
-        long consumed = utilGetMinimumSequence(cast(shared const Sequence[]) gatingSequences, nextValue);
+        long consumed = utilGetMinimumSequence(gatingSequences, nextValue);
         long produced = nextValue;
         return bufferSize - (produced - consumed);
     }

--- a/source/disruptor/util.d
+++ b/source/disruptor/util.d
@@ -21,13 +21,13 @@ int ceilingNextPowerOfTwo(int x)
 }
 
 /// Get the minimum sequence from an array of sequences.
-long getMinimumSequence(shared const(Sequence)[] sequences) @nogc nothrow
+long getMinimumSequence(scope const(shared Sequence)[] sequences) @nogc nothrow
 {
     return getMinimumSequence(sequences, long.max);
 }
 
 /// Get the minimum sequence from an array of sequences with a default value.
-long getMinimumSequence(shared const(Sequence)[] sequences, long minimum) @nogc nothrow
+long getMinimumSequence(scope const(shared Sequence)[] sequences, long minimum) @nogc nothrow
 {
     auto min = minimum;
     foreach (s; sequences)
@@ -83,8 +83,8 @@ unittest
     auto seq2 = new shared Sequence(3);
     auto seq3 = new shared Sequence(12);
     shared Sequence[] seqs = [seq1, seq2, seq3];
-    assert(getMinimumSequence(cast(shared const Sequence[]) seqs) == 3);
-    assert(getMinimumSequence(cast(shared const Sequence[])[]) == long.max);
+    assert(getMinimumSequence(seqs) == 3);
+    assert(getMinimumSequence(cast(shared Sequence[])[]) == long.max);
 
     assertThrown!Exception(log2(0));
     assertThrown!Exception(log2(-1));


### PR DESCRIPTION
## Summary
- update utility function signatures to use `scope const` arrays
- remove casts when calling `getMinimumSequence`
- adjust helper in `SequenceGroup`
- update unit tests

## Testing
- `dub build`
- `dub test`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68711e7804a4832c90cac96a341cfd5d