### PR TITLE
Ensure publish is shared

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -74,8 +74,8 @@ public:
     abstract override long next(int n);
     abstract override long tryNext();
     abstract override long tryNext(int n);
-    abstract override void publish(long sequence);
-    abstract override void publish(long lo, long hi);
+    abstract override void publish(long sequence) shared;
+    abstract override void publish(long lo, long hi) shared;
     abstract override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared;
     EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...)
     {
@@ -108,8 +108,8 @@ unittest
         override long next(int n) { return 0; }
         override long tryNext() { return 0; }
         override long tryNext(int n) { return 0; }
-        override void publish(long sequence) {}
-        override void publish(long lo, long hi) {}
+        override void publish(long sequence) shared {}
+        override void publish(long lo, long hi) shared {}
         override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared { return availableSequence; }
         EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...) { return null; }
     }

--- a/source/disruptor/multiproducersequencer.d
+++ b/source/disruptor/multiproducersequencer.d
@@ -119,17 +119,17 @@ public:
         return bufferSize - (produced - consumed);
     }
 
-    override void publish(long sequence)
+    override void publish(long sequence) shared
     {
-        (cast(shared) this).setAvailable(sequence);
+        setAvailable(sequence);
         waitStrategy.signalAllWhenBlocking();
     }
 
-    override void publish(long lo, long hi)
+    override void publish(long lo, long hi) shared
     {
         for (long l = lo; l <= hi; l++)
         {
-            (cast(shared) this).setAvailable(l);
+            setAvailable(l);
         }
         waitStrategy.signalAllWhenBlocking();
     }
@@ -181,8 +181,8 @@ unittest
 
     auto sequencer = new MultiProducerSequencer(1024, new shared BlockingWaitStrategy());
 
-    sequencer.publish(3);
-    sequencer.publish(5);
+    (cast(shared MultiProducerSequencer)sequencer).publish(3);
+    (cast(shared MultiProducerSequencer)sequencer).publish(5);
 
     auto sharedSeq = cast(shared MultiProducerSequencer)sequencer;
     assert(!sharedSeq.isAvailable(0));

--- a/source/disruptor/processingsequencebarrier.d
+++ b/source/disruptor/processingsequencebarrier.d
@@ -119,8 +119,8 @@ unittest
         override long next(int n) { return 0; }
         override long tryNext() { return 0; }
         override long tryNext(int n) { return 0; }
-        override void publish(long sequence) {}
-        override void publish(long lo, long hi) {}
+        override void publish(long sequence) shared {}
+        override void publish(long lo, long hi) shared {}
         override void claim(long sequence) {}
         override bool isAvailable(long sequence) shared { return false; }
         override void addGatingSequences(shared Sequence[] gatingSequences...) shared {}

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -16,8 +16,8 @@ interface Sequenced
     long next(int n);
     long tryNext();
     long tryNext(int n);
-    void publish(long sequence);
-    void publish(long lo, long hi);
+    void publish(long sequence) shared;
+    void publish(long lo, long hi) shared;
 }
 
 interface SequenceBarrier

--- a/source/disruptor/singleproducersequencer.d
+++ b/source/disruptor/singleproducersequencer.d
@@ -114,13 +114,13 @@ public:
         this.nextValue = sequence;
     }
 
-    override void publish(long sequence)
+    override void publish(long sequence) shared
     {
         cursor.set(sequence);
         waitStrategy.signalAllWhenBlocking();
     }
 
-    override void publish(long lo, long hi)
+    override void publish(long lo, long hi) shared
     {
         publish(hi);
     }
@@ -151,7 +151,7 @@ unittest
         sequencer.hasAvailableCapacity(13);
         assert((cast(shared SingleProducerSequencer)sequencer).getCursor() != next);
 
-        sequencer.publish(next);
+        (cast(shared SingleProducerSequencer)sequencer).publish(next);
     }
 }
 


### PR DESCRIPTION
## Summary
- allow calling `publish` on shared sequencers
- update abstract declarations
- adjust single and multi producer sequencers
- update tests for shared `publish`

## Testing
- `dub test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68718b8cd3b4832c97e9f4252083a1d9