### PR TITLE
Fix shared sequencer tests

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -115,25 +115,25 @@ unittest
     }
 
     auto strategy = new shared SleepingWaitStrategy();
-    auto seq = new DummySequencer(8, strategy);
+    shared DummySequencer seq = cast(shared) new DummySequencer(8, strategy);
 
     auto g1 = new shared Sequence();
     auto g2 = new shared Sequence();
 
-    (cast(shared DummySequencer)seq).addGatingSequences(g1, g2);
+    seq.addGatingSequences(g1, g2);
     assert(g1.get == seq.cursor.get());
     assert(g2.get == seq.cursor.get());
 
-    seq.setCursor(7);
+    (cast(DummySequencer)seq).setCursor(7);
 
     // Both gating sequences at initial value -> minimum equals initial value
-    assert(seq.getMinimumSequence() == Sequence.INITIAL_VALUE);
+    assert((cast(DummySequencer)seq).getMinimumSequence() == Sequence.INITIAL_VALUE);
 
     g1.set(5);
     g2.set(7);
-    assert(seq.getMinimumSequence() == 5);
+    assert((cast(DummySequencer)seq).getMinimumSequence() == 5);
 
-    assert((cast(shared DummySequencer)seq).removeGatingSequence(g1));
-    assert(!(cast(shared DummySequencer)seq).removeGatingSequence(g1));
-    assert(seq.getMinimumSequence() == 7);
+    assert(seq.removeGatingSequence(g1));
+    assert(!seq.removeGatingSequence(g1));
+    assert((cast(DummySequencer)seq).getMinimumSequence() == 7);
 }

--- a/source/disruptor/singleproducersequencer.d
+++ b/source/disruptor/singleproducersequencer.d
@@ -141,17 +141,18 @@ unittest
 {
     import disruptor.yieldingwaitstrategy : YieldingWaitStrategy;
 
-    auto sequencer = new SingleProducerSequencer(16, new shared YieldingWaitStrategy());
+    shared SingleProducerSequencer sequencer =
+        cast(shared) new SingleProducerSequencer(16, new shared YieldingWaitStrategy());
 
     foreach (i; 0 .. 32)
     {
-        auto next = sequencer.next();
-        assert((cast(shared SingleProducerSequencer)sequencer).getCursor() != next);
+        auto next = (cast(SingleProducerSequencer)sequencer).next();
+        assert(sequencer.getCursor() != next);
 
-        sequencer.hasAvailableCapacity(13);
-        assert((cast(shared SingleProducerSequencer)sequencer).getCursor() != next);
+        (cast(SingleProducerSequencer)sequencer).hasAvailableCapacity(13);
+        assert(sequencer.getCursor() != next);
 
-        (cast(shared SingleProducerSequencer)sequencer).publish(next);
+        sequencer.publish(next);
     }
 }
 

--- a/source/disruptor/util.d
+++ b/source/disruptor/util.d
@@ -84,7 +84,8 @@ unittest
     auto seq3 = new shared Sequence(12);
     shared Sequence[] seqs = [seq1, seq2, seq3];
     assert(getMinimumSequence(seqs) == 3);
-    assert(getMinimumSequence(cast(shared Sequence[])[]) == long.max);
+    shared Sequence[] empty;
+    assert(getMinimumSequence(empty) == long.max);
 
     assertThrown!Exception(log2(0));
     assertThrown!Exception(log2(-1));


### PR DESCRIPTION
## Summary
- allocate `DummySequencer` and `SingleProducerSequencer` as shared
- drop casts when calling shared methods
- provide a dedicated empty array in util tests

## Testing
- `dub build`
- `dub test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6871997f9568832caa8e604ffc391d5f