### PR TITLE
Update sequencer tests to use shared instances

### DIFF
--- a/source/disruptor/singleproducersequencer.d
+++ b/source/disruptor/singleproducersequencer.d
@@ -21,6 +21,11 @@ public:
         super(bufferSize, waitStrategy);
     }
 
+    this(int bufferSize, shared WaitStrategy waitStrategy) shared
+    {
+        super(bufferSize, waitStrategy);
+    }
+
     override bool hasAvailableCapacity(int requiredCapacity)
     {
         return hasAvailableCapacity(requiredCapacity, false);
@@ -141,15 +146,15 @@ unittest
 {
     import disruptor.yieldingwaitstrategy : YieldingWaitStrategy;
 
-    auto sequencer = new SingleProducerSequencer(16, new shared YieldingWaitStrategy());
+    auto sequencer = new shared SingleProducerSequencer(16, new shared YieldingWaitStrategy());
 
     foreach (i; 0 .. 32)
     {
-        auto next = sequencer.next();
-        assert((cast(shared SingleProducerSequencer)sequencer).getCursor() != next);
+        auto next = (cast() sequencer).next();
+        assert(sequencer.getCursor() != next);
 
-        sequencer.hasAvailableCapacity(13);
-        assert((cast(shared SingleProducerSequencer)sequencer).getCursor() != next);
+        (cast() sequencer).hasAvailableCapacity(13);
+        assert(sequencer.getCursor() != next);
 
         (cast(shared SingleProducerSequencer)sequencer).publish(next);
     }


### PR DESCRIPTION
## Summary
- instantiate test sequencers as `shared` objects
- remove unnecessary casts in tests
- add `shared` constructors to support `new shared` usage

## Testing
- `dub test`
- `dub build`


------
https://chatgpt.com/codex/tasks/task_e_687199471678832c9baf3ca3588935b0