### PR TITLE
Fix shared API for getMinimumSequence

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -54,7 +54,7 @@ public:
     }
 
     /// Get the minimum sequence seen by gating sequences.
-    override long getMinimumSequence() @nogc nothrow
+    override long getMinimumSequence() shared @nogc nothrow
     {
         return utilGetMinimumSequence(gatingSequences, cursor.get());
     }
@@ -127,13 +127,13 @@ unittest
     (cast(DummySequencer)seq).setCursor(7);
 
     // Both gating sequences at initial value -> minimum equals initial value
-    assert((cast(DummySequencer)seq).getMinimumSequence() == Sequence.INITIAL_VALUE);
+    assert(seq.getMinimumSequence() == Sequence.INITIAL_VALUE);
 
     g1.set(5);
     g2.set(7);
-    assert((cast(DummySequencer)seq).getMinimumSequence() == 5);
+    assert(seq.getMinimumSequence() == 5);
 
     assert(seq.removeGatingSequence(g1));
     assert(!seq.removeGatingSequence(g1));
-    assert((cast(DummySequencer)seq).getMinimumSequence() == 7);
+    assert(seq.getMinimumSequence() == 7);
 }

--- a/source/disruptor/processingsequencebarrier.d
+++ b/source/disruptor/processingsequencebarrier.d
@@ -126,7 +126,7 @@ unittest
         override void addGatingSequences(shared Sequence[] gatingSequences...) shared {}
         override bool removeGatingSequence(shared Sequence sequence) shared { return false; }
         override SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...) shared { return null; }
-        override long getMinimumSequence() { return 0; }
+        override long getMinimumSequence() shared { return 0; }
         override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared { return availableSequence; }
         EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...) { return null; }
     }

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -49,7 +49,7 @@ interface Sequencer : Cursored, Sequenced
     void addGatingSequences(shared Sequence[] gatingSequences...) shared;
     bool removeGatingSequence(shared Sequence sequence) shared;
     SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...) shared;
-    long getMinimumSequence();
+    long getMinimumSequence() shared;
     long getHighestPublishedSequence(long nextSequence, long availableSequence) shared;
     EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...);
 }


### PR DESCRIPTION
## Summary
- mark `getMinimumSequence` in Sequencer as `shared`
- update AbstractSequencer override
- fix DummySequencer in ProcessingSequenceBarrier tests
- adjust tests to call shared method directly

## Testing
- `dub build`
- `dub test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6871b7f30e1c832c87fb33fc6fb59bd8