### PR TITLE
Ensure sequencers support shared access

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -68,12 +68,12 @@ public:
     // Abstract methods to be provided by subclasses.
     abstract override void claim(long sequence);
     abstract override bool isAvailable(long sequence) shared;
-    abstract override bool hasAvailableCapacity(int requiredCapacity);
-    abstract override long remainingCapacity();
-    abstract override long next();
-    abstract override long next(int n);
-    abstract override long tryNext();
-    abstract override long tryNext(int n);
+    abstract override bool hasAvailableCapacity(int requiredCapacity) shared;
+    abstract override long remainingCapacity() shared;
+    abstract override long next() shared;
+    abstract override long next(int n) shared;
+    abstract override long tryNext() shared;
+    abstract override long tryNext(int n) shared;
     abstract override void publish(long sequence) shared;
     abstract override void publish(long lo, long hi) shared;
     abstract override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared;
@@ -102,12 +102,12 @@ unittest
 
         override void claim(long sequence) {}
         override bool isAvailable(long sequence) shared { return true; }
-        override bool hasAvailableCapacity(int requiredCapacity) { return true; }
-        override long remainingCapacity() { return 0; }
-        override long next() { return 0; }
-        override long next(int n) { return 0; }
-        override long tryNext() { return 0; }
-        override long tryNext(int n) { return 0; }
+        override bool hasAvailableCapacity(int requiredCapacity) shared { return true; }
+        override long remainingCapacity() shared { return 0; }
+        override long next() shared { return 0; }
+        override long next(int n) shared { return 0; }
+        override long tryNext() shared { return 0; }
+        override long tryNext(int n) shared { return 0; }
         override void publish(long sequence) shared {}
         override void publish(long lo, long hi) shared {}
         override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared { return availableSequence; }

--- a/source/disruptor/processingsequencebarrier.d
+++ b/source/disruptor/processingsequencebarrier.d
@@ -113,12 +113,12 @@ unittest
         this(shared Sequence cursor) shared { this.cursor = cursor; }
         override long getCursor() shared { return cursor.get(); }
         override int getBufferSize() { return 0; }
-        override bool hasAvailableCapacity(int requiredCapacity) { return false; }
-        override long remainingCapacity() { return 0; }
-        override long next() { return 0; }
-        override long next(int n) { return 0; }
-        override long tryNext() { return 0; }
-        override long tryNext(int n) { return 0; }
+        override bool hasAvailableCapacity(int requiredCapacity) shared { return false; }
+        override long remainingCapacity() shared { return 0; }
+        override long next() shared { return 0; }
+        override long next(int n) shared { return 0; }
+        override long tryNext() shared { return 0; }
+        override long tryNext(int n) shared { return 0; }
         override void publish(long sequence) shared {}
         override void publish(long lo, long hi) shared {}
         override void claim(long sequence) {}

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -10,12 +10,12 @@ interface Cursored
 interface Sequenced
 {
     int getBufferSize();
-    bool hasAvailableCapacity(int requiredCapacity);
-    long remainingCapacity();
-    long next();
-    long next(int n);
-    long tryNext();
-    long tryNext(int n);
+    bool hasAvailableCapacity(int requiredCapacity) shared;
+    long remainingCapacity() shared;
+    long next() shared;
+    long next(int n) shared;
+    long tryNext() shared;
+    long tryNext(int n) shared;
     void publish(long sequence) shared;
     void publish(long lo, long hi) shared;
 }


### PR DESCRIPTION
## Summary
- mark Sequenced interface methods as `shared`
- propagate `shared` overrides through sequencers
- expose shared wrappers for single producer methods
- update tests to call shared methods directly

## Testing
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_6871b7f791ac832cac989efe3953bce4