### PR TITLE
Add shared constructors for sequencers

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -29,6 +29,18 @@ public:
         this.cursor = new shared Sequence(Sequencer.INITIAL_CURSOR_VALUE);
     }
 
+    this(int bufferSize, shared WaitStrategy waitStrategy) shared
+    {
+        if (bufferSize < 1)
+            throw new Exception("bufferSize must not be less than 1");
+        if ((bufferSize & (bufferSize - 1)) != 0)
+            throw new Exception("bufferSize must be a power of 2");
+
+        this.bufferSize = bufferSize;
+        this.waitStrategy = waitStrategy;
+        this.cursor = new shared Sequence(Sequencer.INITIAL_CURSOR_VALUE);
+    }
+
     /// Return the current cursor value.
     override long getCursor() shared @nogc nothrow
     {
@@ -95,6 +107,11 @@ unittest
             super(size, strategy);
         }
 
+        this(int size, shared WaitStrategy strategy) shared
+        {
+            super(size, strategy);
+        }
+
         void setCursor(long value)
         {
             cursor.set(value);
@@ -115,7 +132,7 @@ unittest
     }
 
     auto strategy = new shared SleepingWaitStrategy();
-    shared DummySequencer seq = cast(shared) new DummySequencer(8, strategy);
+    shared DummySequencer seq = new shared DummySequencer(8, strategy);
 
     auto g1 = new shared Sequence();
     auto g2 = new shared Sequence();

--- a/source/disruptor/multiproducersequencer.d
+++ b/source/disruptor/multiproducersequencer.d
@@ -30,6 +30,17 @@ public:
         indexShift = log2(bufferSize);
     }
 
+    this(int bufferSize, shared WaitStrategy waitStrategy) shared
+    {
+        super(bufferSize, waitStrategy);
+        gatingSequenceCache = new shared Sequence(Sequencer.INITIAL_CURSOR_VALUE);
+        availableBuffer = new shared int[](bufferSize);
+        foreach (i; 0 .. bufferSize)
+            availableBuffer[i] = -1;
+        indexMask = bufferSize - 1;
+        indexShift = log2(bufferSize);
+    }
+
     override bool hasAvailableCapacity(int requiredCapacity) shared
     {
         return (cast(MultiProducerSequencer)this)
@@ -182,7 +193,7 @@ unittest
     import disruptor.blockingwaitstrategy : BlockingWaitStrategy;
 
     shared MultiProducerSequencer sequencer =
-        cast(shared) new MultiProducerSequencer(1024, new shared BlockingWaitStrategy());
+        new shared MultiProducerSequencer(1024, new shared BlockingWaitStrategy());
 
     sequencer.publish(3);
     sequencer.publish(5);

--- a/source/disruptor/singleproducersequencer.d
+++ b/source/disruptor/singleproducersequencer.d
@@ -21,6 +21,11 @@ public:
         super(bufferSize, waitStrategy);
     }
 
+    this(int bufferSize, shared WaitStrategy waitStrategy) shared
+    {
+        super(bufferSize, waitStrategy);
+    }
+
     bool hasAvailableCapacity(int requiredCapacity)
     {
         return hasAvailableCapacity(requiredCapacity, false);
@@ -173,7 +178,7 @@ unittest
     import disruptor.yieldingwaitstrategy : YieldingWaitStrategy;
 
     shared SingleProducerSequencer sequencer =
-        cast(shared) new SingleProducerSequencer(16, new shared YieldingWaitStrategy());
+        new shared SingleProducerSequencer(16, new shared YieldingWaitStrategy());
 
     foreach (i; 0 .. 32)
     {


### PR DESCRIPTION
## Summary
- add shared constructor to `AbstractSequencer`
- implement shared constructors in `SingleProducerSequencer` and `MultiProducerSequencer`
- allocate sequencers with `new shared` in unittests

## Testing
- `./gradlew test`
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_6871c17c7620832cbe72a6d02cd2d028