### PR TITLE
Fix shared DummySequencer setCursor call

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -112,7 +112,7 @@ unittest
             super(size, strategy);
         }
 
-        void setCursor(long value)
+        void setCursor(long value) shared
         {
             cursor.set(value);
         }
@@ -141,7 +141,7 @@ unittest
     assert(g1.get == seq.cursor.get());
     assert(g2.get == seq.cursor.get());
 
-    (cast(DummySequencer)seq).setCursor(7);
+    seq.setCursor(7);
 
     // Both gating sequences at initial value -> minimum equals initial value
     assert(seq.getMinimumSequence() == Sequence.INITIAL_VALUE);


### PR DESCRIPTION
## Summary
- declare `DummySequencer.setCursor` as `shared`
- invoke `setCursor` directly in the unittest

## Testing
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_6871e491b660832cb22353a62abce2c2