### PR TITLE
Update coding guidelines about shared constructors

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -10,5 +10,6 @@ This repository includes a D port of the Disruptor. When migrating Java code to 
 - **Use selective imports** – prefer `import module : symbol;` to remove unnecessary imports.
 - **Apply attributes** – mark functions and variables with attributes such as `shared`, `nothrow`, `@safe`, `in`, and others where appropriate.
 - **Use `shared` consistently** – declare methods that operate on shared instances with `shared` (e.g., `long get() const shared`). Parameters and local variables referencing shared objects should use the `shared` type qualifier (e.g., `shared Sequence[]`). Initialize shared objects with `new shared Type(...)`. See `sequence.d`, `sequencegroup.d`, and `processingsequencebarrier.d` for examples.
+- **Avoid `cast(shared)`** – rather than casting, provide constructors or helper functions that return properly `shared` objects. For example, `ProcessingSequenceBarrier`'s constructors should initialize all shared fields without any casting.
 
 Following these practices will help maintain clarity and quality as the code base evolves.


### PR DESCRIPTION
## Summary
- discourage using `cast(shared)`
- mention `ProcessingSequenceBarrier` constructors as an example

## Testing
- `./gradlew test`
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_6871ffbd5cb4832cbe05b06e39e0f4b2