### PR TITLE
Add event interfaces modules

### DIFF
--- a/source/disruptor/eventfactory.d
+++ b/source/disruptor/eventfactory.d
@@ -1,0 +1,21 @@
+module disruptor.eventfactory;
+
+/// Factory interface for pre-populating events in the RingBuffer.
+interface EventFactory(T)
+{
+    /// Create a new instance of the event.
+    T newInstance();
+}
+
+unittest
+{
+    class MyEvent { int value; }
+
+    class MyFactory : EventFactory!MyEvent
+    {
+        override MyEvent newInstance() { return new MyEvent(); }
+    }
+
+    auto factory = new MyFactory();
+    assert(factory.newInstance() !is null);
+}

--- a/source/disruptor/eventsequencer.d
+++ b/source/disruptor/eventsequencer.d
@@ -1,0 +1,19 @@
+module disruptor.eventsequencer;
+
+/// Pulls together low-level data access and sequencing operations.
+interface EventSequencer(T)
+{
+    /// Get the event for a given sequence.
+    T get(long sequence);
+}
+
+unittest
+{
+    class DummySequencer : EventSequencer!int
+    {
+        override int get(long sequence) { return cast(int)sequence; }
+    }
+
+    auto seq = new DummySequencer();
+    assert(seq.get(5) == 5);
+}

--- a/source/disruptor/eventsink.d
+++ b/source/disruptor/eventsink.d
@@ -1,0 +1,94 @@
+module disruptor.eventsink;
+
+public import disruptor.eventtranslator;
+
+/// Write interface for a ring buffer.
+interface EventSink(E)
+{
+    void publishEvent(EventTranslator!E translator);
+    bool tryPublishEvent(EventTranslator!E translator);
+
+    void publishEvent(A)(EventTranslatorOneArg!(E, A) translator, A arg0);
+    bool tryPublishEvent(A)(EventTranslatorOneArg!(E, A) translator, A arg0);
+
+    void publishEvent(A, B)(EventTranslatorTwoArg!(E, A, B) translator, A arg0, B arg1);
+    bool tryPublishEvent(A, B)(EventTranslatorTwoArg!(E, A, B) translator, A arg0, B arg1);
+
+    void publishEvent(A, B, C)(EventTranslatorThreeArg!(E, A, B, C) translator, A arg0, B arg1, C arg2);
+    bool tryPublishEvent(A, B, C)(EventTranslatorThreeArg!(E, A, B, C) translator, A arg0, B arg1, C arg2);
+
+    void publishEvent(Args...)(EventTranslatorVararg!E translator, Args args);
+    bool tryPublishEvent(Args...)(EventTranslatorVararg!E translator, Args args);
+
+    void publishEvents(EventTranslator!E[] translators);
+    void publishEvents(EventTranslator!E[] translators, int batchStartsAt, int batchSize);
+    bool tryPublishEvents(EventTranslator!E[] translators);
+    bool tryPublishEvents(EventTranslator!E[] translators, int batchStartsAt, int batchSize);
+
+    void publishEvents(A)(EventTranslatorOneArg!(E, A) translator, A[] arg0);
+    void publishEvents(A)(EventTranslatorOneArg!(E, A) translator, int batchStartsAt, int batchSize, A[] arg0);
+    bool tryPublishEvents(A)(EventTranslatorOneArg!(E, A) translator, A[] arg0);
+    bool tryPublishEvents(A)(EventTranslatorOneArg!(E, A) translator, int batchStartsAt, int batchSize, A[] arg0);
+
+    void publishEvents(A, B)(EventTranslatorTwoArg!(E, A, B) translator, A[] arg0, B[] arg1);
+    void publishEvents(A, B)(EventTranslatorTwoArg!(E, A, B) translator, int batchStartsAt, int batchSize, A[] arg0, B[] arg1);
+    bool tryPublishEvents(A, B)(EventTranslatorTwoArg!(E, A, B) translator, A[] arg0, B[] arg1);
+    bool tryPublishEvents(A, B)(EventTranslatorTwoArg!(E, A, B) translator, int batchStartsAt, int batchSize, A[] arg0, B[] arg1);
+
+    void publishEvents(A, B, C)(EventTranslatorThreeArg!(E, A, B, C) translator, A[] arg0, B[] arg1, C[] arg2);
+    void publishEvents(A, B, C)(EventTranslatorThreeArg!(E, A, B, C) translator, int batchStartsAt, int batchSize, A[] arg0, B[] arg1, C[] arg2);
+    bool tryPublishEvents(A, B, C)(EventTranslatorThreeArg!(E, A, B, C) translator, A[] arg0, B[] arg1, C[] arg2);
+    bool tryPublishEvents(A, B, C)(EventTranslatorThreeArg!(E, A, B, C) translator, int batchStartsAt, int batchSize, A[] arg0, B[] arg1, C[] arg2);
+
+    void publishEvents(Args...)(EventTranslatorVararg!E translator, Args[] args);
+    void publishEvents(Args...)(EventTranslatorVararg!E translator, int batchStartsAt, int batchSize, Args[] args);
+    bool tryPublishEvents(Args...)(EventTranslatorVararg!E translator, Args[] args);
+    bool tryPublishEvents(Args...)(EventTranslatorVararg!E translator, int batchStartsAt, int batchSize, Args[] args);
+}
+
+unittest
+{
+    class MyEvent { int value; }
+
+    class NoopTranslator : EventTranslator!MyEvent
+    {
+        override void translateTo(MyEvent event, long sequence) { event.value = 1; }
+    }
+
+    class DummySink : EventSink!MyEvent
+    {
+        override void publishEvent(EventTranslator!MyEvent translator) {}
+        override bool tryPublishEvent(EventTranslator!MyEvent translator) { return true; }
+        void publishEvent(A)(EventTranslatorOneArg!(MyEvent, A) translator, A arg0) {}
+        bool tryPublishEvent(A)(EventTranslatorOneArg!(MyEvent, A) translator, A arg0) { return true; }
+        void publishEvent(A,B)(EventTranslatorTwoArg!(MyEvent, A, B) translator, A arg0, B arg1) {}
+        bool tryPublishEvent(A,B)(EventTranslatorTwoArg!(MyEvent, A, B) translator, A arg0, B arg1) { return true; }
+        void publishEvent(A,B,C)(EventTranslatorThreeArg!(MyEvent, A, B, C) translator, A arg0, B arg1, C arg2) {}
+        bool tryPublishEvent(A,B,C)(EventTranslatorThreeArg!(MyEvent, A, B, C) translator, A arg0, B arg1, C arg2) { return true; }
+        void publishEvent(Args...)(EventTranslatorVararg!MyEvent translator, Args args) {}
+        bool tryPublishEvent(Args...)(EventTranslatorVararg!MyEvent translator, Args args) { return true; }
+        override void publishEvents(EventTranslator!MyEvent[] translators) {}
+        override void publishEvents(EventTranslator!MyEvent[] translators, int batchStartsAt, int batchSize) {}
+        override bool tryPublishEvents(EventTranslator!MyEvent[] translators) { return true; }
+        override bool tryPublishEvents(EventTranslator!MyEvent[] translators, int batchStartsAt, int batchSize) { return true; }
+        void publishEvents(A)(EventTranslatorOneArg!(MyEvent, A) translator, A[] arg0) {}
+        void publishEvents(A)(EventTranslatorOneArg!(MyEvent, A) translator, int batchStartsAt, int batchSize, A[] arg0) {}
+        bool tryPublishEvents(A)(EventTranslatorOneArg!(MyEvent, A) translator, A[] arg0) { return true; }
+        bool tryPublishEvents(A)(EventTranslatorOneArg!(MyEvent, A) translator, int batchStartsAt, int batchSize, A[] arg0) { return true; }
+        void publishEvents(A,B)(EventTranslatorTwoArg!(MyEvent, A, B) translator, A[] arg0, B[] arg1) {}
+        void publishEvents(A,B)(EventTranslatorTwoArg!(MyEvent, A, B) translator, int batchStartsAt, int batchSize, A[] arg0, B[] arg1) {}
+        bool tryPublishEvents(A,B)(EventTranslatorTwoArg!(MyEvent, A, B) translator, A[] arg0, B[] arg1) { return true; }
+        bool tryPublishEvents(A,B)(EventTranslatorTwoArg!(MyEvent, A, B) translator, int batchStartsAt, int batchSize, A[] arg0, B[] arg1) { return true; }
+        void publishEvents(A,B,C)(EventTranslatorThreeArg!(MyEvent, A, B, C) translator, A[] arg0, B[] arg1, C[] arg2) {}
+        void publishEvents(A,B,C)(EventTranslatorThreeArg!(MyEvent, A, B, C) translator, int batchStartsAt, int batchSize, A[] arg0, B[] arg1, C[] arg2) {}
+        bool tryPublishEvents(A,B,C)(EventTranslatorThreeArg!(MyEvent, A, B, C) translator, A[] arg0, B[] arg1, C[] arg2) { return true; }
+        bool tryPublishEvents(A,B,C)(EventTranslatorThreeArg!(MyEvent, A, B, C) translator, int batchStartsAt, int batchSize, A[] arg0, B[] arg1, C[] arg2) { return true; }
+        void publishEvents(Args...)(EventTranslatorVararg!MyEvent translator, Args[] args) {}
+        void publishEvents(Args...)(EventTranslatorVararg!MyEvent translator, int batchStartsAt, int batchSize, Args[] args) {}
+        bool tryPublishEvents(Args...)(EventTranslatorVararg!MyEvent translator, Args[] args) { return true; }
+        bool tryPublishEvents(Args...)(EventTranslatorVararg!MyEvent translator, int batchStartsAt, int batchSize, Args[] args) { return true; }
+    }
+
+    auto sink = new DummySink();
+    sink.publishEvent(new NoopTranslator());
+}

--- a/source/disruptor/eventtranslator.d
+++ b/source/disruptor/eventtranslator.d
@@ -1,0 +1,73 @@
+module disruptor.eventtranslator;
+
+/// Interfaces for translating data representations into events.
+
+interface EventTranslator(T)
+{
+    /// Translate data into the given event for the specified sequence.
+    void translateTo(T event, long sequence);
+}
+
+interface EventTranslatorOneArg(T, A)
+{
+    void translateTo(T event, long sequence, A arg0);
+}
+
+interface EventTranslatorTwoArg(T, A, B)
+{
+    void translateTo(T event, long sequence, A arg0, B arg1);
+}
+
+interface EventTranslatorThreeArg(T, A, B, C)
+{
+    void translateTo(T event, long sequence, A arg0, B arg1, C arg2);
+}
+
+/// Vararg translator accepting an arbitrary list of arguments.
+interface EventTranslatorVararg(T)
+{
+    void translateTo(Args...)(T event, long sequence, Args args);
+}
+
+unittest
+{
+    class MyEvent { int value; }
+
+    class MyTranslator : EventTranslator!MyEvent
+    {
+        override void translateTo(MyEvent event, long sequence)
+        {
+            event.value = cast(int)sequence;
+        }
+    }
+
+    auto e = new MyEvent();
+    auto t = new MyTranslator();
+    t.translateTo(e, 7);
+    assert(e.value == 7);
+
+    class MyOneArg : EventTranslatorOneArg!(MyEvent, int)
+    {
+        override void translateTo(MyEvent event, long sequence, int arg0)
+        {
+            event.value = arg0;
+        }
+    }
+
+    auto t1 = new MyOneArg();
+    t1.translateTo(e, 1, 42);
+    assert(e.value == 42);
+
+    class MyVararg : EventTranslatorVararg!MyEvent
+    {
+        void translateTo(Args...)(MyEvent event, long sequence, Args args)
+        {
+            static if (Args.length > 0 && is(typeof(args[0]) == int))
+                event.value = args[0];
+        }
+    }
+
+    auto tv = new MyVararg();
+    tv.translateTo(e, 2, 5);
+    assert(e.value == 5);
+}

--- a/source/disruptor/package.d
+++ b/source/disruptor/package.d
@@ -12,3 +12,7 @@ public import disruptor.util;
 public import disruptor.insufficientcapacityexception;
 public import disruptor.multiproducersequencer;
 public import disruptor.singleproducersequencer;
+public import disruptor.eventfactory;
+public import disruptor.eventtranslator;
+public import disruptor.eventsink;
+public import disruptor.eventsequencer;


### PR DESCRIPTION
## Summary
- define `EventFactory` interface
- define `EventTranslator` interfaces
- add `EventSink` interface mirroring Java methods
- add `EventSequencer` interface
- expose new modules in `package.d`
- provide basic unittests for each new module

## Testing
- `dub build`
- `dub test`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68720932a1f8832cbdd0ac72b6ce6a63