### PR TITLE
Improve shared guidelines

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -9,7 +9,7 @@ This repository includes a D port of the Disruptor. When migrating Java code to 
 - **Organize imports** – group all `public import` statements together at the start of each file.
 - **Use selective imports** – prefer `import module : symbol;` to remove unnecessary imports.
 - **Apply attributes** – mark functions and variables with attributes such as `shared`, `nothrow`, `@safe`, `in`, and others where appropriate.
-- **Use `shared` consistently** – declare methods that operate on shared instances with `shared` (e.g., `long get() const shared`). Parameters and local variables referencing shared objects should use the `shared` type qualifier (e.g., `shared Sequence[]`). Initialize shared objects with `new shared Type(...)`. See `sequence.d`, `sequencegroup.d`, and `processingsequencebarrier.d` for examples.
+- **Use `shared` consistently** – apply the qualifier to methods and interface definitions that operate on shared instances (e.g., `long get() const shared`). Provide dedicated `this() shared` constructors or factory functions so objects can be created in a shared state without casts. Parameters and local variables referencing shared objects should also use the `shared` type qualifier (e.g., `shared Sequence[]`). Initialize shared objects with `new shared Type(...)`. See `sequence.d`, `sequencegroup.d`, `processingsequencebarrier.d`, `sequencer.d`, and `ringbuffer.d` for examples.
 - **Avoid `cast(shared)`** – rather than casting, provide constructors or helper functions that return properly `shared` objects. For example, `ProcessingSequenceBarrier`'s constructors should initialize all shared fields without any casting.
 
 Following these practices will help maintain clarity and quality as the code base evolves.


### PR DESCRIPTION
## Summary
- clarify how to use `shared` consistently in CODING_GUIDELINES

## Testing
- `./gradlew test`
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_6872196facc8832c849e599e271514f4