### PR TITLE
Update get methods to const shared

### DIFF
--- a/source/disruptor/eventsequencer.d
+++ b/source/disruptor/eventsequencer.d
@@ -4,16 +4,16 @@ module disruptor.eventsequencer;
 interface EventSequencer(T)
 {
     /// Get the event for a given sequence.
-    T get(long sequence);
+    T get(long sequence) const shared;
 }
 
 unittest
 {
     class DummySequencer : EventSequencer!int
     {
-        override int get(long sequence) { return cast(int)sequence; }
+        override int get(long sequence) const shared { return cast(int)sequence; }
     }
 
-    auto seq = new DummySequencer();
+    shared DummySequencer seq = new shared DummySequencer();
     assert(seq.get(5) == 5);
 }

--- a/source/disruptor/ringbuffer.d
+++ b/source/disruptor/ringbuffer.d
@@ -53,7 +53,7 @@ public:
         return new shared RingBuffer!T(factory, bufferSize, seq);
     }
 
-    override T get(long sequence)
+    override T get(long sequence) const shared
     {
         return cast(T) entries[cast(size_t)(sequence & indexMask)];
     }
@@ -145,12 +145,11 @@ unittest
 
     auto rb = RingBuffer!StubEvent.createSingleProducer(() => new shared StubEvent(), 4, new shared BlockingWaitStrategy());
     auto seq = rb.next();
-    auto unshared = cast(RingBuffer!StubEvent) rb;
-    auto evt = unshared.get(seq);
+    auto evt = rb.get(seq);
     evt.value = 42;
     rb.publish(seq);
 
-    assert(unshared.get(seq).value == 42);
+    assert(rb.get(seq).value == 42);
 
     auto g1 = new shared Sequence();
     auto g2 = new shared Sequence();

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -32,7 +32,7 @@ interface SequenceBarrier
 
 interface DataProvider(T)
 {
-    T get(long sequence);
+    T get(long sequence) const shared;
 }
 
 class EventPoller(T)


### PR DESCRIPTION
## Summary
- update `DataProvider.get` to be `const shared`
- declare `EventSequencer.get` as `const shared`
- implement `RingBuffer.get` with the new qualifiers
- adjust example `DummySequencer` and ring buffer unittest

## Testing
- `dub test`

------
https://chatgpt.com/codex/tasks/task_e_687226f312fc832caabf5911300916dd