### PR TITLE
Fix shared signature for RingBuffer.get

### DIFF
--- a/source/disruptor/ringbuffer.d
+++ b/source/disruptor/ringbuffer.d
@@ -53,7 +53,7 @@ public:
         return new shared RingBuffer!T(factory, bufferSize, seq);
     }
 
-    override T get(long sequence)
+    override T get(long sequence) shared
     {
         return cast(T) entries[cast(size_t)(sequence & indexMask)];
     }
@@ -145,12 +145,11 @@ unittest
 
     auto rb = RingBuffer!StubEvent.createSingleProducer(() => new shared StubEvent(), 4, new shared BlockingWaitStrategy());
     auto seq = rb.next();
-    auto unshared = cast(RingBuffer!StubEvent) rb;
-    auto evt = unshared.get(seq);
+    auto evt = rb.get(seq);
     evt.value = 42;
     rb.publish(seq);
 
-    assert(unshared.get(seq).value == 42);
+    assert(rb.get(seq).value == 42);
 
     auto g1 = new shared Sequence();
     auto g2 = new shared Sequence();

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -32,7 +32,7 @@ interface SequenceBarrier
 
 interface DataProvider(T)
 {
-    T get(long sequence);
+    T get(long sequence) shared;
 }
 
 class EventPoller(T)


### PR DESCRIPTION
## Summary
- make `DataProvider.get` callable on shared instances
- update `RingBuffer.get` implementation
- adjust ring buffer unit tests to avoid casting

## Testing
- `dub build`
- `dub test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_687226f7346c832c8d9401f02480238b