### PR TITLE
Return shared SequenceBarrier

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -72,9 +72,9 @@ public:
     }
 
     /// Create a new sequence barrier tracking the given sequences.
-    override SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...) shared
+    override shared(SequenceBarrier) newBarrier(shared Sequence[] sequencesToTrack...) shared
     {
-        return new ProcessingSequenceBarrier(this, waitStrategy, cursor, sequencesToTrack);
+        return new shared ProcessingSequenceBarrier(this, waitStrategy, cursor, sequencesToTrack);
     }
 
     // Abstract methods to be provided by subclasses.

--- a/source/disruptor/processingsequencebarrier.d
+++ b/source/disruptor/processingsequencebarrier.d
@@ -131,7 +131,7 @@ unittest
         override bool isAvailable(long sequence) shared { return false; }
         override void addGatingSequences(shared Sequence[] gatingSequences...) shared {}
         override bool removeGatingSequence(shared Sequence sequence) shared { return false; }
-        override SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...) shared { return null; }
+        override shared(SequenceBarrier) newBarrier(shared Sequence[] sequencesToTrack...) shared { return null; }
         override long getMinimumSequence() shared { return 0; }
         override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared { return availableSequence; }
         EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...) { return null; }

--- a/source/disruptor/ringbuffer.d
+++ b/source/disruptor/ringbuffer.d
@@ -128,7 +128,7 @@ public:
         return sequencer.removeGatingSequence(sequence);
     }
 
-    SequenceBarrier newBarrier(shared Sequence[] sequences...) shared
+    shared(SequenceBarrier) newBarrier(shared Sequence[] sequences...) shared
     {
         return sequencer.newBarrier(sequences);
     }

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -48,7 +48,7 @@ interface Sequencer : Cursored, Sequenced
     bool isAvailable(long sequence) shared;
     void addGatingSequences(shared Sequence[] gatingSequences...) shared;
     bool removeGatingSequence(shared Sequence sequence) shared;
-    SequenceBarrier newBarrier(shared Sequence[] sequencesToTrack...) shared;
+    shared(SequenceBarrier) newBarrier(shared Sequence[] sequencesToTrack...) shared;
     long getMinimumSequence() shared;
     long getHighestPublishedSequence(long nextSequence, long availableSequence) shared;
     EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...);


### PR DESCRIPTION
## Summary
- make Sequencer.newBarrier return `shared SequenceBarrier`
- update AbstractSequencer and RingBuffer overrides
- adapt unittest dummy implementation

## Testing
- `dub build`
- `dub test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68722c1751e8832ca9233b10d967342c