### PR TITLE
Return shared from DataProvider

### DIFF
--- a/source/disruptor/ringbuffer.d
+++ b/source/disruptor/ringbuffer.d
@@ -53,9 +53,9 @@ public:
         return new shared RingBuffer!T(factory, bufferSize, seq);
     }
 
-    override T get(long sequence) shared
+    override shared(T) get(long sequence) shared
     {
-        return cast(T) entries[cast(size_t)(sequence & indexMask)];
+        return entries[cast(size_t)(sequence & indexMask)];
     }
 
     override long next() shared
@@ -145,11 +145,11 @@ unittest
 
     auto rb = RingBuffer!StubEvent.createSingleProducer(() => new shared StubEvent(), 4, new shared BlockingWaitStrategy());
     auto seq = rb.next();
-    auto evt = rb.get(seq);
+    auto evt = cast(StubEvent) rb.get(seq);
     evt.value = 42;
     rb.publish(seq);
 
-    assert(rb.get(seq).value == 42);
+    assert((cast(StubEvent) rb.get(seq)).value == 42);
 
     auto g1 = new shared Sequence();
     auto g2 = new shared Sequence();

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -32,7 +32,7 @@ interface SequenceBarrier
 
 interface DataProvider(T)
 {
-    T get(long sequence) shared;
+    shared(T) get(long sequence) shared;
 }
 
 class EventPoller(T)


### PR DESCRIPTION
## Summary
- update the D `DataProvider` interface to return `shared(T)`
- update `RingBuffer.get` to match new return type and drop the cast
- adjust `RingBuffer` unit test for the shared return value

## Testing
- `./gradlew test --no-daemon`
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_68722c252470832c82714f0044c4c53b