### PR TITLE
Update DataProvider to return shared entries

### DIFF
--- a/source/disruptor/ringbuffer.d
+++ b/source/disruptor/ringbuffer.d
@@ -53,9 +53,9 @@ public:
         return new shared RingBuffer!T(factory, bufferSize, seq);
     }
 
-    override T get(long sequence) shared
+    override shared(T) get(long sequence) shared
     {
-        return cast(T) entries[cast(size_t)(sequence & indexMask)];
+        return entries[cast(size_t)(sequence & indexMask)];
     }
 
     override long next() shared
@@ -145,11 +145,11 @@ unittest
 
     auto rb = RingBuffer!StubEvent.createSingleProducer(() => new shared StubEvent(), 4, new shared BlockingWaitStrategy());
     auto seq = rb.next();
-    auto evt = rb.get(seq);
+    auto evt = cast(StubEvent) rb.get(seq);
     evt.value = 42;
     rb.publish(seq);
 
-    assert(rb.get(seq).value == 42);
+    assert((cast(StubEvent) rb.get(seq)).value == 42);
 
     auto g1 = new shared Sequence();
     auto g2 = new shared Sequence();

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -32,7 +32,8 @@ interface SequenceBarrier
 
 interface DataProvider(T)
 {
-    T get(long sequence) shared;
+    /// Retrieve an entry from the underlying data source.
+    shared(T) get(long sequence) shared;
 }
 
 class EventPoller(T)


### PR DESCRIPTION
## Summary
- adjust `DataProvider` interface to return `shared(T)`
- update `RingBuffer.get` to return shared entry without casting
- fix unit test to cast returned entry to mutable form

## Testing
- `dub build`
- `dub test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68722c2e4cf0832cae1f3f55f38e1e05