### PR TITLE
Align DataProvider API with shared events

### DIFF
--- a/source/disruptor/ringbuffer.d
+++ b/source/disruptor/ringbuffer.d
@@ -53,9 +53,9 @@ public:
         return new shared RingBuffer!T(factory, bufferSize, seq);
     }
 
-    override T get(long sequence) shared
+    override shared(T) get(long sequence) shared
     {
-        return cast(T) entries[cast(size_t)(sequence & indexMask)];
+        return entries[cast(size_t)(sequence & indexMask)];
     }
 
     override long next() shared
@@ -146,7 +146,7 @@ unittest
     auto rb = RingBuffer!StubEvent.createSingleProducer(() => new shared StubEvent(), 4, new shared BlockingWaitStrategy());
     auto seq = rb.next();
     auto evt = rb.get(seq);
-    evt.value = 42;
+    (cast(StubEvent) evt).value = 42;
     rb.publish(seq);
 
     assert(rb.get(seq).value == 42);

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -32,7 +32,7 @@ interface SequenceBarrier
 
 interface DataProvider(T)
 {
-    T get(long sequence) shared;
+    shared(T) get(long sequence) shared;
 }
 
 class EventPoller(T)


### PR DESCRIPTION
## Summary
- return `shared(T)` from `DataProvider.get`
- update `RingBuffer` implementation
- adjust unit tests for new signature

## Testing
- `dub test`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68722cace734832cb074e7299dcb9083