### PR TITLE
Update EventSequencer.get return type

### DIFF
--- a/source/disruptor/eventsequencer.d
+++ b/source/disruptor/eventsequencer.d
@@ -4,14 +4,17 @@ module disruptor.eventsequencer;
 interface EventSequencer(T)
 {
     /// Get the event for a given sequence.
-    T get(long sequence) shared;
+    shared(T) get(long sequence) shared;
 }
 
 unittest
 {
     class DummySequencer : EventSequencer!int
     {
-        override int get(long sequence) shared { return cast(int)sequence; }
+        override shared(int) get(long sequence) shared
+        {
+            return cast(shared(int))sequence;
+        }
     }
 
     auto seq = new shared DummySequencer();


### PR DESCRIPTION
## Summary
- return `shared(T)` from `EventSequencer.get`
- adjust `DummySequencer` unit test

## Testing
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_6872371d9b74832ca97811a1a4abe7dd