### PR TITLE
Add EventProcessor interface

### DIFF
--- a/source/disruptor/eventprocessor.d
+++ b/source/disruptor/eventprocessor.d
@@ -1,0 +1,44 @@
+module disruptor.eventprocessor;
+
+import disruptor.sequence : Sequence;
+
+/// An EventProcessor runs in a thread to poll events from the RingBuffer.
+interface EventProcessor
+{
+    /// Main processing loop.
+    void run() shared;
+
+    /// Get the Sequence tracked by this processor.
+    shared(Sequence) getSequence() shared;
+
+    /// Signal the processor to stop when it reaches a safe point.
+    void halt() shared;
+
+    /// Whether the processor is currently running.
+    bool isRunning() shared;
+}
+
+unittest
+{
+    class StubProcessor : EventProcessor
+    {
+        private shared Sequence seq;
+        private shared bool running = false;
+
+        this() shared
+        {
+            seq = new shared Sequence();
+        }
+
+        override void run() shared { running = true; }
+        override shared(Sequence) getSequence() shared { return seq; }
+        override void halt() shared { running = false; }
+        override bool isRunning() shared { return running; }
+    }
+
+    auto p = new shared StubProcessor();
+    p.run();
+    assert(p.isRunning());
+    p.halt();
+    assert(!p.isRunning());
+}

--- a/source/disruptor/package.d
+++ b/source/disruptor/package.d
@@ -16,4 +16,5 @@ public import disruptor.eventfactory;
 public import disruptor.eventtranslator;
 public import disruptor.eventsink;
 public import disruptor.eventsequencer;
+public import disruptor.eventprocessor;
 public import disruptor.ringbuffer;


### PR DESCRIPTION
## Summary
- port `EventProcessor` interface to D
- expose the module via `package.d`
- provide a unit test for a stub implementation

## Testing
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_687242e1ea1c832ca4b5c92efea7abe4