### PR TITLE
Add EventPoller API

### DIFF
--- a/source/disruptor/eventpoller.d
+++ b/source/disruptor/eventpoller.d
@@ -1,0 +1,111 @@
+module disruptor.eventpoller;
+
+import disruptor.sequencer : Sequencer, DataProvider;
+import disruptor.sequence : Sequence;
+import disruptor.fixedsequencegroup : FixedSequenceGroup;
+
+/// Experimental poll-based processor for events.
+class EventPoller(T)
+{
+private:
+    shared DataProvider!T _dataProvider;
+    shared Sequencer _sequencer;
+    shared Sequence _sequence;
+    shared Sequence _gatingSequence;
+
+public:
+    /// Callback for consuming events.
+    interface Handler(T)
+    {
+        bool onEvent(shared(T) event, long sequence, bool endOfBatch);
+    }
+
+    /// Result of a poll attempt.
+    enum PollState
+    {
+        PROCESSING,
+        GATING,
+        IDLE
+    }
+
+    this(shared DataProvider!T dataProvider,
+         shared Sequencer sequencer,
+         shared Sequence sequence,
+         shared Sequence gatingSequence) shared
+    {
+        _dataProvider = dataProvider;
+        _sequencer = sequencer;
+        _sequence = sequence;
+        _gatingSequence = gatingSequence;
+    }
+
+    PollState poll(Handler!T eventHandler) shared
+    {
+        long currentSequence = _sequence.get();
+        long nextSequence = currentSequence + 1;
+        long availableSequence =
+            _sequencer.getHighestPublishedSequence(nextSequence, _gatingSequence.get());
+
+        if (nextSequence <= availableSequence)
+        {
+            bool processNextEvent;
+            long processedSequence = currentSequence;
+
+            try
+            {
+                do
+                {
+                    auto event = _dataProvider.get(nextSequence);
+                    processNextEvent = eventHandler.onEvent(event, nextSequence,
+                        nextSequence == availableSequence);
+                    processedSequence = nextSequence;
+                    nextSequence++;
+                }
+                while (nextSequence <= availableSequence && processNextEvent);
+            }
+            finally
+            {
+                _sequence.set(processedSequence);
+            }
+
+            return PollState.PROCESSING;
+        }
+        else if (_sequencer.getCursor() >= nextSequence)
+        {
+            return PollState.GATING;
+        }
+        else
+        {
+            return PollState.IDLE;
+        }
+    }
+
+    static shared(EventPoller!T) newInstance(T)(shared DataProvider!T dataProvider,
+                                                shared Sequencer sequencer,
+                                                shared Sequence sequence,
+                                                shared Sequence cursorSequence,
+                                                shared Sequence[] gatingSequences = [])
+    {
+        shared Sequence gatingSequence;
+        if (gatingSequences.length == 0)
+        {
+            gatingSequence = cursorSequence;
+        }
+        else if (gatingSequences.length == 1)
+        {
+            gatingSequence = gatingSequences[0];
+        }
+        else
+        {
+            gatingSequence = new shared FixedSequenceGroup(gatingSequences);
+        }
+
+        return new shared EventPoller!T(dataProvider, sequencer, sequence, gatingSequence);
+    }
+
+    shared(Sequence) getSequence() shared
+    {
+        return _sequence;
+    }
+}
+

--- a/source/disruptor/package.d
+++ b/source/disruptor/package.d
@@ -17,3 +17,4 @@ public import disruptor.eventtranslator;
 public import disruptor.eventsink;
 public import disruptor.eventsequencer;
 public import disruptor.ringbuffer;
+public import disruptor.eventpoller;

--- a/source/disruptor/processingsequencebarrier.d
+++ b/source/disruptor/processingsequencebarrier.d
@@ -4,7 +4,8 @@ import core.atomic;
 import disruptor.sequence : Sequence;
 import disruptor.fixedsequencegroup : FixedSequenceGroup;
 import disruptor.waitstrategy : WaitStrategy;
-import disruptor.sequencer : Sequencer, SequenceBarrier, DataProvider, EventPoller;
+import disruptor.sequencer : Sequencer, SequenceBarrier, DataProvider;
+import disruptor.eventpoller : EventPoller;
 
 /// Exception thrown when a SequenceBarrier is alerted.
 class AlertException : Exception
@@ -134,7 +135,10 @@ unittest
         override shared(SequenceBarrier) newBarrier(shared Sequence[] sequencesToTrack...) shared { return null; }
         override long getMinimumSequence() shared { return 0; }
         override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared { return availableSequence; }
-        EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...) { return null; }
+        shared(EventPoller!T) newPoller(T)(shared DataProvider!T provider, shared Sequence[] gatingSequences...) shared
+        {
+            return null;
+        }
     }
 
     auto cursor = new shared Sequence(10);

--- a/source/disruptor/ringbuffer.d
+++ b/source/disruptor/ringbuffer.d
@@ -1,6 +1,8 @@
 module disruptor.ringbuffer;
 
-import disruptor.sequencer : Sequencer, Sequenced, Cursored, SequenceBarrier, DataProvider, EventPoller;
+import disruptor.sequencer : Sequencer, Sequenced, Cursored, SequenceBarrier, DataProvider;
+import disruptor.eventpoller : EventPoller;
+import disruptor.abstractsequencer : AbstractSequencer;
 import disruptor.sequence : Sequence;
 import disruptor.singleproducersequencer : SingleProducerSequencer;
 import disruptor.multiproducersequencer : MultiProducerSequencer;
@@ -126,6 +128,12 @@ public:
     bool removeGatingSequence(shared Sequence sequence) shared
     {
         return sequencer.removeGatingSequence(sequence);
+    }
+
+    shared(EventPoller!T) newPoller(shared Sequence[] gatingSequences = []) shared
+    {
+        auto seq = cast(shared AbstractSequencer)sequencer;
+        return seq.newPoller!T(this, gatingSequences);
     }
 
     shared(SequenceBarrier) newBarrier(shared Sequence[] sequences...) shared

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -35,11 +35,6 @@ interface DataProvider(T)
     shared(T) get(long sequence) shared;
 }
 
-class EventPoller(T)
-{
-    // placeholder class
-}
-
 interface Sequencer : Cursored, Sequenced
 {
     enum long INITIAL_CURSOR_VALUE = -1;


### PR DESCRIPTION
## Summary
- implement `newPoller` in `AbstractSequencer`
- expose new `EventPoller` class
- wire `RingBuffer.newPoller` to sequencer
- re-export `eventpoller` from package
- adjust tests and imports

## Testing
- `dub build`
- `dub test`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687242e02694832c916c20bcb1164e1b