### PR TITLE
Add event handler abstractions

### DIFF
--- a/source/disruptor/eventhandler.d
+++ b/source/disruptor/eventhandler.d
@@ -1,0 +1,67 @@
+module disruptor.eventhandler;
+
+public import disruptor.sequence : Sequence;
+
+/// Marker interface to allow identification of Disruptor event handlers.
+interface EventHandlerIdentity
+{
+}
+
+/// Base interface for handling events from the RingBuffer.
+interface EventHandlerBase(T) : EventHandlerIdentity
+{
+    /// Called when a publisher has published an event.
+    void onEvent(shared(T) event, long sequence, bool endOfBatch) shared;
+
+    /// Invoked by a BatchEventProcessor prior to processing a batch of events.
+    void onBatchStart(long batchSize, long queueDepth) shared;
+
+    /// Called once on thread start before first event is available.
+    void onStart() shared;
+
+    /// Called once just before the event processing thread is shutdown.
+    void onShutdown() shared;
+
+    /// Invoked when a WaitStrategy times out waiting for an event.
+    void onTimeout(long sequence) shared;
+}
+
+/// Extended interface used by EventProcessors to notify of sequence progress.
+interface EventHandler(T) : EventHandlerBase!T
+{
+    /// Set a callback sequence to notify when events have been processed.
+    void setSequenceCallback(shared Sequence sequenceCallback) shared;
+}
+
+/// Convenience base class providing default no-op implementations for the
+/// optional lifecycle callbacks.
+abstract class EventHandlerAdapter(T) : EventHandler!T
+{
+    override void onBatchStart(long batchSize, long queueDepth) shared {}
+    override void onStart() shared {}
+    override void onShutdown() shared {}
+    override void onTimeout(long sequence) shared {}
+    override void setSequenceCallback(shared Sequence sequenceCallback) shared {}
+}
+
+unittest
+{
+    class MyEvent { int value; }
+
+    class MyHandler : EventHandlerAdapter!MyEvent
+    {
+        override void onEvent(shared(MyEvent) event, long sequence, bool endOfBatch) shared
+        {
+            event.value = cast(int)sequence;
+        }
+    }
+
+    static assert(is(MyHandler : EventHandler!MyEvent));
+
+    auto handler = new shared MyHandler();
+    handler.onStart();
+    handler.onBatchStart(1, 1);
+    handler.onTimeout(0);
+    handler.onShutdown();
+    handler.onEvent(new shared MyEvent(), 1, true);
+}

--- a/source/disruptor/package.d
+++ b/source/disruptor/package.d
@@ -17,6 +17,7 @@ public import disruptor.eventtranslator;
 public import disruptor.eventsink;
 public import disruptor.eventsequencer;
 public import disruptor.eventprocessor;
+public import disruptor.eventhandler;
 public import disruptor.ringbuffer;
 public import disruptor.timeoutblockingwaitstrategy;
 public import disruptor.timeoutexception;


### PR DESCRIPTION
## Summary
- implement `EventHandlerIdentity`, `EventHandlerBase`, and `EventHandler` in a new module
- expose `eventhandler` via `package.d`
- provide a simple `EventHandlerAdapter` with default no-op methods
- add unittests for interface compliance and default callbacks

## Testing
- `dub test -q`

------
https://chatgpt.com/codex/tasks/task_e_687269cd8650832cbea0eff83509baaa