### PR TITLE
Implement EventPoller

### DIFF
--- a/source/disruptor/abstractsequencer.d
+++ b/source/disruptor/abstractsequencer.d
@@ -89,9 +89,10 @@ public:
     abstract override void publish(long sequence) shared;
     abstract override void publish(long lo, long hi) shared;
     abstract override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared;
-    EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...)
+    shared(EventPoller!T) newPoller(T)(shared DataProvider!T provider, shared Sequence[] gatingSequences...) shared
     {
-        return null;
+        return EventPoller!T.newInstance(provider,
+                cast(shared Sequencer)this, new shared Sequence(), cursor, gatingSequences);
     }
 }
 
@@ -128,7 +129,7 @@ unittest
         override void publish(long sequence) shared {}
         override void publish(long lo, long hi) shared {}
         override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared { return availableSequence; }
-        EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...) { return null; }
+        shared(EventPoller!T) newPoller(T)(shared DataProvider!T provider, shared Sequence[] gatingSequences...) shared { return null; }
     }
 
     auto strategy = new shared SleepingWaitStrategy();

--- a/source/disruptor/eventpoller.d
+++ b/source/disruptor/eventpoller.d
@@ -1,0 +1,158 @@
+module disruptor.eventpoller;
+
+import disruptor.sequence : Sequence;
+import disruptor.fixedsequencegroup : FixedSequenceGroup;
+import disruptor.sequencer : DataProvider, Sequencer;
+
+/**
+ * Experimental poll-based interface similar to the Java version.
+ */
+class EventPoller(T)
+{
+    private shared(DataProvider!T) _dataProvider;
+    private shared Sequencer _sequencer;
+    private shared Sequence _sequence;
+    private shared Sequence _gatingSequence;
+
+    /// Callback used to consume events from the poller.
+    interface Handler
+    {
+        bool onEvent(shared(T) event, long sequence, bool endOfBatch);
+    }
+
+    /// Result of a poll attempt.
+    enum PollState
+    {
+        PROCESSING,
+        GATING,
+        IDLE
+    }
+
+    this(shared DataProvider!T dataProvider, shared Sequencer sequencer,
+            shared Sequence sequence, shared Sequence gatingSequence)
+    {
+        _dataProvider = dataProvider;
+        _sequencer = sequencer;
+        _sequence = sequence;
+        _gatingSequence = gatingSequence;
+    }
+
+    this(shared DataProvider!T dataProvider, shared Sequencer sequencer,
+            shared Sequence sequence, shared Sequence gatingSequence) shared
+    {
+        _dataProvider = dataProvider;
+        _sequencer = sequencer;
+        _sequence = sequence;
+        _gatingSequence = gatingSequence;
+    }
+
+    /// Poll for events using the supplied handler.
+    PollState poll(Handler handler) shared
+    {
+        auto currentSequence = _sequence.get();
+        auto nextSequence = currentSequence + 1;
+        auto availableSequence =
+            _sequencer.getHighestPublishedSequence(nextSequence, _gatingSequence.get());
+
+        if (nextSequence <= availableSequence)
+        {
+            bool processNext;
+            long processedSequence = currentSequence;
+            try
+            {
+                do
+                {
+                    auto evt = _dataProvider.get(nextSequence);
+                    processNext = handler.onEvent(evt, nextSequence, nextSequence == availableSequence);
+                    processedSequence = nextSequence;
+                    nextSequence++;
+                }
+                while (nextSequence <= availableSequence && processNext);
+            }
+            finally
+            {
+                _sequence.set(processedSequence);
+            }
+            return PollState.PROCESSING;
+        }
+        else if (_sequencer.getCursor() >= nextSequence)
+        {
+            return PollState.GATING;
+        }
+        else
+        {
+            return PollState.IDLE;
+        }
+    }
+
+    /// Create a new EventPoller instance gating on the supplied sequences.
+    static shared(EventPoller!T) newInstance(T)(shared DataProvider!T dataProvider,
+            shared Sequencer sequencer, shared Sequence sequence,
+            shared Sequence cursorSequence, shared Sequence[] gatingSequences...)
+    {
+        shared Sequence gating;
+        if (gatingSequences.length == 0)
+        {
+            gating = cursorSequence;
+        }
+        else if (gatingSequences.length == 1)
+        {
+            gating = gatingSequences[0];
+        }
+        else
+        {
+            gating = new shared FixedSequenceGroup(gatingSequences);
+        }
+        return new shared EventPoller!T(dataProvider, sequencer, sequence, gating);
+    }
+
+    /// Get the sequence tracked by this poller.
+    shared(Sequence) getSequence() shared
+    {
+        return _sequence;
+    }
+}
+
+unittest
+{
+    import disruptor.singleproducersequencer : SingleProducerSequencer;
+    import disruptor.waitstrategy : BusySpinWaitStrategy;
+
+    shared int[] data = new shared int[](16);
+
+    class IntProvider : DataProvider!int
+    {
+        override shared(int) get(long seq) shared { return data[cast(size_t) seq]; }
+    }
+
+    auto sequencer = new shared SingleProducerSequencer(16, new shared BusySpinWaitStrategy());
+    auto gating = new shared Sequence();
+    auto provider = new shared IntProvider();
+    auto poller = sequencer.newPoller(provider, gating);
+
+    class H : EventPoller!int.Handler
+    {
+        int count;
+        override bool onEvent(shared(int) evt, long seq, bool end) { ++count; return false; }
+    }
+
+    auto h = new H();
+
+    // Initially idle
+    assert(poller.poll(h) == EventPoller!int.PollState.IDLE);
+
+    // publish one event
+    auto next = sequencer.next();
+    data[next] = 7;
+    sequencer.publish(next);
+
+    // gating not advanced yet
+    assert(poller.poll(h) == EventPoller!int.PollState.GATING);
+    assert(h.count == 0);
+
+    gating.incrementAndGet();
+    assert(poller.poll(h) == EventPoller!int.PollState.PROCESSING);
+    assert(h.count == 1);
+    assert(poller.getSequence().get() == next);
+}
+

--- a/source/disruptor/package.d
+++ b/source/disruptor/package.d
@@ -17,6 +17,7 @@ public import disruptor.eventtranslator;
 public import disruptor.eventsink;
 public import disruptor.eventsequencer;
 public import disruptor.eventprocessor;
+public import disruptor.eventpoller;
 public import disruptor.ringbuffer;
 public import disruptor.timeoutblockingwaitstrategy;
 public import disruptor.timeoutexception;

--- a/source/disruptor/processingsequencebarrier.d
+++ b/source/disruptor/processingsequencebarrier.d
@@ -134,7 +134,7 @@ unittest
         override shared(SequenceBarrier) newBarrier(shared Sequence[] sequencesToTrack...) shared { return null; }
         override long getMinimumSequence() shared { return 0; }
         override long getHighestPublishedSequence(long nextSequence, long availableSequence) shared { return availableSequence; }
-        EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...) { return null; }
+        shared(EventPoller!T) newPoller(T)(shared DataProvider!T provider, shared Sequence[] gatingSequences...) shared { return null; }
     }
 
     auto cursor = new shared Sequence(10);

--- a/source/disruptor/ringbuffer.d
+++ b/source/disruptor/ringbuffer.d
@@ -1,6 +1,7 @@
 module disruptor.ringbuffer;
 
 import disruptor.sequencer : Sequencer, Sequenced, Cursored, SequenceBarrier, DataProvider, EventPoller;
+import disruptor.abstractsequencer : AbstractSequencer;
 import disruptor.sequence : Sequence;
 import disruptor.singleproducersequencer : SingleProducerSequencer;
 import disruptor.multiproducersequencer : MultiProducerSequencer;
@@ -129,6 +130,12 @@ public:
     bool removeGatingSequence(shared Sequence sequence) shared
     {
         return sequencer.removeGatingSequence(sequence);
+    }
+
+    shared(EventPoller!T) newPoller(shared Sequence[] gatingSequences...) shared
+    {
+        auto seq = cast(shared AbstractSequencer)sequencer;
+        return seq.newPoller!T(this, gatingSequences);
     }
 
     shared(SequenceBarrier) newBarrier(shared Sequence[] sequences...) shared

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -1,6 +1,7 @@
 module disruptor.sequencer;
 
 import disruptor.sequence;
+public import disruptor.eventpoller : EventPoller; // expose EventPoller
 
 interface Cursored
 {
@@ -35,11 +36,6 @@ interface DataProvider(T)
     shared(T) get(long sequence) shared;
 }
 
-class EventPoller(T)
-{
-    // placeholder class
-}
-
 interface Sequencer : Cursored, Sequenced
 {
     enum long INITIAL_CURSOR_VALUE = -1;
@@ -51,5 +47,5 @@ interface Sequencer : Cursored, Sequenced
     shared(SequenceBarrier) newBarrier(shared Sequence[] sequencesToTrack...) shared;
     long getMinimumSequence() shared;
     long getHighestPublishedSequence(long nextSequence, long availableSequence) shared;
-    EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...);
+    shared(EventPoller!T) newPoller(T)(shared DataProvider!T provider, shared Sequence[] gatingSequences...) shared;
 }


### PR DESCRIPTION
## Summary
- add `EventPoller` implementation with polling logic and unit tests
- implement `newPoller` in `AbstractSequencer` and `RingBuffer`
- expose the new module via `package.d`
- adjust sequencer interface and tests

## Testing
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_687269c81860832c876bdc48d2cec707