### PR TITLE
Refactor to avoid cast(shared) usage

### DIFF
--- a/source/disruptor/eventpoller.d
+++ b/source/disruptor/eventpoller.d
@@ -154,8 +154,8 @@ unittest
         auto provider = new shared Provider(data);
 
         auto poller = sequencer.newPoller!Object(provider, gatingSequence);
-        auto obj = new Object();
-        data[0] = cast(shared Object) obj;
+        auto obj = new shared Object();
+        data[0] = obj;
 
         assert(poller.poll(handler) == PollState.IDLE);
 

--- a/source/disruptor/eventsequencer.d
+++ b/source/disruptor/eventsequencer.d
@@ -13,7 +13,8 @@ unittest
     {
         override shared(int) get(long sequence) shared
         {
-            return cast(shared(int))sequence;
+            shared int value = cast(int)sequence;
+            return value;
         }
     }
 

--- a/source/disruptor/ringbuffer.d
+++ b/source/disruptor/ringbuffer.d
@@ -20,9 +20,9 @@ private:
     shared T[] entries;
     int indexMask;
     int bufferSize;
-    shared Sequencer sequencer;
+    shared AbstractSequencer sequencer;
 
-    this(EventFactory!T factory, int bufferSize, shared Sequencer sequencer)
+    this(EventFactory!T factory, int bufferSize, shared AbstractSequencer sequencer)
     {
         this.bufferSize = bufferSize;
         this.indexMask = bufferSize - 1;
@@ -32,7 +32,7 @@ private:
             entries[i] = factory();
     }
 
-    this(EventFactory!T factory, int bufferSize, shared Sequencer sequencer) shared
+    this(EventFactory!T factory, int bufferSize, shared AbstractSequencer sequencer) shared
     {
         this.bufferSize = bufferSize;
         this.indexMask = bufferSize - 1;
@@ -139,8 +139,7 @@ public:
 
     shared(EventPoller!T) newPoller(shared Sequence[] gatingSequences...) shared
     {
-        auto seq = cast(shared AbstractSequencer)sequencer;
-        return seq.newPoller!T(cast(shared DataProvider!T)this, gatingSequences);
+        return sequencer.newPoller!T(this, gatingSequences);
     }
 
     // EventSink implementation using translators ---------------------------------

--- a/source/disruptor/sequencer.d
+++ b/source/disruptor/sequencer.d
@@ -48,5 +48,7 @@ interface Sequencer : Cursored, Sequenced
     shared(SequenceBarrier) newBarrier(shared Sequence[] sequencesToTrack...) shared;
     long getMinimumSequence() shared;
     long getHighestPublishedSequence(long nextSequence, long availableSequence) shared;
-    EventPoller!T newPoller(T)(DataProvider!T provider, shared Sequence[] gatingSequences...);
+    /// Create a new {@link EventPoller} bound to this sequencer.
+    shared(EventPoller!T) newPoller(T)(shared DataProvider!T provider,
+                                        shared Sequence[] gatingSequences...) shared;
 }


### PR DESCRIPTION
## Summary
- remove cast(shared) by storing the sequencer as `AbstractSequencer`
- tidy EventSequencer and EventPoller tests to construct shared objects
- update Sequencer interface to expose a shared `newPoller`

## Testing
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_6872f104fce8832c8462e15c22230dee