### PR TITLE
Add batch rewind support in D BatchEventProcessor

### DIFF
--- a/source/disruptor/batchrewindstrategy.d
+++ b/source/disruptor/batchrewindstrategy.d
@@ -1,0 +1,11 @@
+module disruptor.batchrewindstrategy;
+
+import disruptor.rewindableexception : RewindableException;
+import disruptor.rewindaction : RewindAction;
+
+/// Strategy for handling a RewindableException when processing an event batch.
+interface BatchRewindStrategy
+{
+    RewindAction handleRewindException(RewindableException e, int attempts) shared;
+}
+

--- a/source/disruptor/package.d
+++ b/source/disruptor/package.d
@@ -25,3 +25,6 @@ public import disruptor.timeoutexception;
 public import disruptor.eventhandler;
 public import disruptor.rewindableeventhandler;
 public import disruptor.rewindableexception;
+public import disruptor.rewindaction;
+public import disruptor.batchrewindstrategy;
+public import disruptor.simplebatchrewindstrategy;

--- a/source/disruptor/rewindaction.d
+++ b/source/disruptor/rewindaction.d
@@ -1,0 +1,11 @@
+module disruptor.rewindaction;
+
+/// Decision returned by a BatchRewindStrategy on how to handle a RewindableException.
+enum RewindAction
+{
+    /// Rewind and replay the whole batch.
+    REWIND,
+    /// Propagate the exception to the configured ExceptionHandler.
+    THROW
+}
+

--- a/source/disruptor/simplebatchrewindstrategy.d
+++ b/source/disruptor/simplebatchrewindstrategy.d
@@ -1,0 +1,15 @@
+module disruptor.simplebatchrewindstrategy;
+
+import disruptor.batchrewindstrategy : BatchRewindStrategy;
+import disruptor.rewindaction : RewindAction;
+import disruptor.rewindableexception : RewindableException;
+
+/// Batch rewind strategy that always rewinds.
+class SimpleBatchRewindStrategy : BatchRewindStrategy
+{
+    override RewindAction handleRewindException(RewindableException e, int attempts) shared
+    {
+        return RewindAction.REWIND;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `BatchRewindStrategy` infrastructure for D implementation
- support optional rewind strategy in `BatchEventProcessor`
- handle `RewindableException` in processing loop
- expose new modules from `package.d`
- test batch rewind behaviour

## Testing
- `dub test -q`
- `./gradlew test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6872fadea574832c83863410cdb9fcea