### PR TITLE
Add ProducerType enum and ring buffer create factory

### DIFF
--- a/source/disruptor/package.d
+++ b/source/disruptor/package.d
@@ -19,6 +19,7 @@ public import disruptor.eventsequencer;
 public import disruptor.eventprocessor;
 public import disruptor.batcheventprocessor;
 public import disruptor.ringbuffer;
+public import disruptor.producertype;
 public import disruptor.eventpoller;
 public import disruptor.timeoutblockingwaitstrategy;
 public import disruptor.timeoutexception;

--- a/source/disruptor/producertype.d
+++ b/source/disruptor/producertype.d
@@ -1,0 +1,10 @@
+module disruptor.producertype;
+
+/// Defines producer types for RingBuffer creation.
+enum ProducerType
+{
+    /// Single publisher only.
+    SINGLE,
+    /// Supports multiple concurrent publishers.
+    MULTI
+}


### PR DESCRIPTION
## Summary
- add `ProducerType` enum matching the Java API
- support producer type in `RingBuffer.create`
- expose `ProducerType` from the package
- test new factory method

## Testing
- `dub build`
- `dub test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_687325f6b654832c97774d7ac6efa392