### PR TITLE
Switch RingBuffer to EventFactory interface

### DIFF
--- a/source/disruptor/batcheventprocessor.d
+++ b/source/disruptor/batcheventprocessor.d
@@ -319,7 +319,12 @@ unittest
         }
     }
 
-    auto rb = RingBuffer!StubEvent.createSingleProducer(() => new shared StubEvent(), 4, new shared BlockingWaitStrategy());
+    import disruptor.eventfactory : makeEventFactory;
+
+    auto rb = RingBuffer!StubEvent.createSingleProducer(
+        makeEventFactory!StubEvent(() => new shared StubEvent()),
+        4,
+        new shared BlockingWaitStrategy());
     auto barrier = rb.newBarrier();
     auto handler = new shared CountingHandler();
     auto processor = BatchEventProcessor!StubEvent.newInstance(rb, barrier, handler, 16);
@@ -368,7 +373,12 @@ unittest
         override void handleOnShutdownException(Throwable ex) shared {}
     }
 
-    auto rb = RingBuffer!StubEvent.createSingleProducer(() => new shared StubEvent(), 4, new shared BlockingWaitStrategy());
+    import disruptor.eventfactory : makeEventFactory;
+
+    auto rb = RingBuffer!StubEvent.createSingleProducer(
+        makeEventFactory!StubEvent(() => new shared StubEvent()),
+        4,
+        new shared BlockingWaitStrategy());
     auto barrier = rb.newBarrier();
     auto handler = new shared ExceptionThrower();
     auto processor = BatchEventProcessor!StubEvent.newInstance(rb, barrier, handler, 16);
@@ -421,7 +431,12 @@ unittest
         }
     }
 
-    auto rb = RingBuffer!StubEvent.createSingleProducer(() => new shared StubEvent(), 16, new shared BlockingWaitStrategy());
+    import disruptor.eventfactory : makeEventFactory;
+
+    auto rb = RingBuffer!StubEvent.createSingleProducer(
+        makeEventFactory!StubEvent(() => new shared StubEvent()),
+        16,
+        new shared BlockingWaitStrategy());
     auto barrier = rb.newBarrier();
     auto handler = new shared BatchLimitRecordingHandler();
     auto processor = BatchEventProcessor!StubEvent.newInstance(rb, barrier, handler, MAX_BATCH_SIZE);
@@ -468,7 +483,12 @@ unittest
         }
     }
 
-    auto rb = RingBuffer!StubEvent.createSingleProducer(() => new shared StubEvent(), 4, new shared BlockingWaitStrategy());
+    import disruptor.eventfactory : makeEventFactory;
+
+    auto rb = RingBuffer!StubEvent.createSingleProducer(
+        makeEventFactory!StubEvent(() => new shared StubEvent()),
+        4,
+        new shared BlockingWaitStrategy());
     auto barrier = rb.newBarrier();
     auto handler = new shared RewindingHandler();
     auto processor = BatchEventProcessor!StubEvent.newInstance(cast(shared DataProvider!StubEvent)rb,
@@ -501,7 +521,12 @@ unittest
         override void onEvent(StubEvent evt, long seq, bool endOfBatch) shared {}
     }
 
-    auto rb = RingBuffer!StubEvent.createSingleProducer(() => new shared StubEvent(), 4, new shared BlockingWaitStrategy());
+    import disruptor.eventfactory : makeEventFactory;
+
+    auto rb = RingBuffer!StubEvent.createSingleProducer(
+        makeEventFactory!StubEvent(() => new shared StubEvent()),
+        4,
+        new shared BlockingWaitStrategy());
     auto barrier = rb.newBarrier();
     auto handler = new shared DummyHandler();
     auto processor = new shared BatchEventProcessor!StubEvent(rb, barrier, handler, 16);
@@ -535,7 +560,12 @@ unittest
         }
     }
 
-    auto rb = RingBuffer!StubEvent.createSingleProducer(() => new shared StubEvent(), 4, new shared BlockingWaitStrategy());
+    import disruptor.eventfactory : makeEventFactory;
+
+    auto rb = RingBuffer!StubEvent.createSingleProducer(
+        makeEventFactory!StubEvent(() => new shared StubEvent()),
+        4,
+        new shared BlockingWaitStrategy());
     auto barrier = rb.newBarrier();
     auto handler = new shared CountingHandler();
     auto processor = new shared BatchEventProcessor!StubEvent(rb, barrier, handler, 16);

--- a/source/disruptor/eventfactory.d
+++ b/source/disruptor/eventfactory.d
@@ -4,7 +4,29 @@ module disruptor.eventfactory;
 interface EventFactory(T)
 {
     /// Create a new instance of the event.
-    shared(T) newInstance() @safe;
+    shared(T) newInstance() shared @safe;
+}
+
+/// Wrap a delegate to create an `EventFactory` implementation.
+class DelegateEventFactory(T) : EventFactory!T
+{
+    shared(T) delegate() @safe _create;
+
+    this(shared(T) delegate() @safe create) shared
+    {
+        _create = create;
+    }
+
+    override shared(T) newInstance() shared @safe
+    {
+        return _create();
+    }
+}
+
+/// Convenience function to create a shared `EventFactory` from a delegate.
+shared(EventFactory!T) makeEventFactory(T)(shared(T) delegate() @safe create)
+{
+    return new shared DelegateEventFactory!T(create);
 }
 
 unittest
@@ -13,10 +35,13 @@ unittest
 
     class MyFactory : EventFactory!MyEvent
     {
-        override shared(MyEvent) newInstance() @safe { return new shared MyEvent(); }
+        override shared(MyEvent) newInstance() shared @safe
+        {
+            return new shared MyEvent();
+        }
     }
 
-    auto factory = new MyFactory();
+    auto factory = new shared MyFactory();
     auto evt = factory.newInstance();
     assert(evt !is null);
 }

--- a/source/disruptor/eventpoller.d
+++ b/source/disruptor/eventpoller.d
@@ -169,7 +169,7 @@ unittest
 
     // Test polling from a ring buffer when full
     {
-        import disruptor.eventfactory : EventFactory;
+        import disruptor.eventfactory : makeEventFactory;
 
         byte[][] events;
         class ByteHandler : Handler!(byte[])
@@ -182,7 +182,10 @@ unittest
         }
         auto handler = new ByteHandler();
 
-        auto ringBuffer = RingBuffer!(byte[]).createMultiProducer({ return new shared byte[](1); }, 4, new shared SleepingWaitStrategy());
+        auto ringBuffer = RingBuffer!(byte[]).createMultiProducer(
+            makeEventFactory!(byte[])(() => new shared byte[](1)),
+            4,
+            new shared SleepingWaitStrategy());
         auto poller = ringBuffer.newPoller();
         ringBuffer.addGatingSequences(poller.getSequence());
 


### PR DESCRIPTION
## Summary
- refactor `RingBuffer` to use the `EventFactory` interface instead of a delegate alias
- add helper `DelegateEventFactory` and `makeEventFactory` to wrap delegates
- update constructors and factory methods of `RingBuffer` to take shared `EventFactory` objects
- rewrite tests to build event factories using `makeEventFactory`

## Testing
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_687351a0ed68832c933bfaf36a8d73e9