### PR TITLE
Annotate dummy barriers with @safe nothrow

### DIFF
--- a/source/disruptor/batchrewindstrategy.d
+++ b/source/disruptor/batchrewindstrategy.d
@@ -6,6 +6,6 @@ import disruptor.rewindableexception : RewindableException;
 /// Strategy invoked when a RewindableException occurs during batch processing.
 interface BatchRewindStrategy
 {
-    RewindAction handleRewindException(RewindableException e, int attempts) shared;
+    RewindAction handleRewindException(RewindableException e, int attempts) shared @safe nothrow;
 }
 

--- a/source/disruptor/blockingwaitstrategy.d
+++ b/source/disruptor/blockingwaitstrategy.d
@@ -57,12 +57,12 @@ unittest
 
     class DummySequenceBarrier : SequenceBarrier
     {
-        override long waitFor(long sequence) shared { return 0; }
-        override long getCursor() shared { return 0; }
-        override bool isAlerted() shared { return false; }
-        override void alert() shared {}
-        override void clearAlert() shared {}
-        override void checkAlert() shared {}
+        override long waitFor(long sequence) shared @safe nothrow { return 0; }
+        override long getCursor() shared @safe nothrow { return 0; }
+        override bool isAlerted() shared @safe nothrow { return false; }
+        override void alert() shared @safe nothrow {}
+        override void clearAlert() shared @safe nothrow {}
+        override void checkAlert() shared @safe nothrow {}
     }
 
     auto strategy = new shared BlockingWaitStrategy();

--- a/source/disruptor/eventuallygiveupbatchrewindstrategy.d
+++ b/source/disruptor/eventuallygiveupbatchrewindstrategy.d
@@ -9,12 +9,12 @@ class EventuallyGiveUpBatchRewindStrategy : BatchRewindStrategy
 {
     private long _maxAttempts;
 
-    this(long maxAttempts) shared
+    this(long maxAttempts) shared @safe nothrow
     {
         _maxAttempts = maxAttempts;
     }
 
-    override RewindAction handleRewindException(RewindableException e, int attempts) shared
+    override RewindAction handleRewindException(RewindableException e, int attempts) shared @safe nothrow
     {
         if (attempts == _maxAttempts)
         {

--- a/source/disruptor/liteblockingwaitstrategy.d
+++ b/source/disruptor/liteblockingwaitstrategy.d
@@ -78,12 +78,12 @@ unittest
 
     class DummySequenceBarrier : SequenceBarrier
     {
-        override long waitFor(long sequence) shared { return 0; }
-        override long getCursor() shared { return 0; }
-        override bool isAlerted() shared { return false; }
-        override void alert() shared {}
-        override void clearAlert() shared {}
-        override void checkAlert() shared {}
+        override long waitFor(long sequence) shared @safe nothrow { return 0; }
+        override long getCursor() shared @safe nothrow { return 0; }
+        override bool isAlerted() shared @safe nothrow { return false; }
+        override void alert() shared @safe nothrow {}
+        override void clearAlert() shared @safe nothrow {}
+        override void checkAlert() shared @safe nothrow {}
     }
 
     auto strategy = new shared LiteBlockingWaitStrategy();

--- a/source/disruptor/litetimeoutblockingwaitstrategy.d
+++ b/source/disruptor/litetimeoutblockingwaitstrategy.d
@@ -80,12 +80,12 @@ unittest
 
     class DummySequenceBarrier : SequenceBarrier
     {
-        override long waitFor(long sequence) shared { return 0; }
-        override long getCursor() shared { return 0; }
-        override bool isAlerted() shared { return false; }
-        override void alert() shared {}
-        override void clearAlert() shared {}
-        override void checkAlert() shared {}
+        override long waitFor(long sequence) shared @safe nothrow { return 0; }
+        override long getCursor() shared @safe nothrow { return 0; }
+        override bool isAlerted() shared @safe nothrow { return false; }
+        override void alert() shared @safe nothrow {}
+        override void clearAlert() shared @safe nothrow {}
+        override void checkAlert() shared @safe nothrow {}
     }
 
     enum theTimeout = 50;

--- a/source/disruptor/nanosecondpausebatchrewindstrategy.d
+++ b/source/disruptor/nanosecondpausebatchrewindstrategy.d
@@ -11,12 +11,12 @@ class NanosecondPauseBatchRewindStrategy : BatchRewindStrategy
 {
     private long _nanoSecondPauseTime;
 
-    this(long nanoSecondPauseTime) shared
+    this(long nanoSecondPauseTime) shared @safe nothrow
     {
         _nanoSecondPauseTime = nanoSecondPauseTime;
     }
 
-    override RewindAction handleRewindException(RewindableException e, int attempts) shared
+    override RewindAction handleRewindException(RewindableException e, int attempts) shared @safe nothrow
     {
         Thread.sleep(nsecs(_nanoSecondPauseTime));
         return RewindAction.REWIND;

--- a/source/disruptor/phasedbackoffwaitstrategy.d
+++ b/source/disruptor/phasedbackoffwaitstrategy.d
@@ -95,12 +95,12 @@ unittest
 
     class DummySequenceBarrier : SequenceBarrier
     {
-        override long waitFor(long sequence) shared { return 0; }
-        override long getCursor() shared { return 0; }
-        override bool isAlerted() shared { return false; }
-        override void alert() shared {}
-        override void clearAlert() shared {}
-        override void checkAlert() shared {}
+        override long waitFor(long sequence) shared @safe nothrow { return 0; }
+        override long getCursor() shared @safe nothrow { return 0; }
+        override bool isAlerted() shared @safe nothrow { return false; }
+        override void alert() shared @safe nothrow {}
+        override void clearAlert() shared @safe nothrow {}
+        override void checkAlert() shared @safe nothrow {}
     }
 
     auto strategy1 = PhasedBackoffWaitStrategy.withLock(msecs(1), msecs(1));

--- a/source/disruptor/rewindbatcheventprocessor.d
+++ b/source/disruptor/rewindbatcheventprocessor.d
@@ -183,7 +183,7 @@ unittest
     class CountingStrategy : BatchRewindStrategy
     {
         int count;
-        override RewindAction handleRewindException(RewindableException e, int attempts) shared
+        override RewindAction handleRewindException(RewindableException e, int attempts) shared @safe nothrow
         {
             atomicOp!"+="(count, 1);
             return RewindAction.REWIND;

--- a/source/disruptor/simplebatchrewindstrategy.d
+++ b/source/disruptor/simplebatchrewindstrategy.d
@@ -7,7 +7,7 @@ import disruptor.rewindaction : RewindAction;
 /// Batch rewind strategy that always rewinds.
 class SimpleBatchRewindStrategy : BatchRewindStrategy
 {
-    override RewindAction handleRewindException(RewindableException e, int attempts) shared
+    override RewindAction handleRewindException(RewindableException e, int attempts) shared @safe nothrow
     {
         return RewindAction.REWIND;
     }

--- a/source/disruptor/sleepingwaitstrategy.d
+++ b/source/disruptor/sleepingwaitstrategy.d
@@ -76,12 +76,12 @@ unittest
 
     class DummySequenceBarrier : SequenceBarrier
     {
-        override long waitFor(long sequence) shared { return 0; }
-        override long getCursor() shared { return 0; }
-        override bool isAlerted() shared { return false; }
-        override void alert() shared {}
-        override void clearAlert() shared {}
-        override void checkAlert() shared {}
+        override long waitFor(long sequence) shared @safe nothrow { return 0; }
+        override long getCursor() shared @safe nothrow { return 0; }
+        override bool isAlerted() shared @safe nothrow { return false; }
+        override void alert() shared @safe nothrow {}
+        override void clearAlert() shared @safe nothrow {}
+        override void checkAlert() shared @safe nothrow {}
     }
 
     auto strategy = new shared SleepingWaitStrategy();

--- a/source/disruptor/timeoutblockingwaitstrategy.d
+++ b/source/disruptor/timeoutblockingwaitstrategy.d
@@ -78,12 +78,12 @@ unittest
 
     class DummySequenceBarrier : SequenceBarrier
     {
-        override long waitFor(long sequence) shared { return 0; }
-        override long getCursor() shared { return 0; }
-        override bool isAlerted() shared { return false; }
-        override void alert() shared {}
-        override void clearAlert() shared {}
-        override void checkAlert() shared {}
+        override long waitFor(long sequence) shared @safe nothrow { return 0; }
+        override long getCursor() shared @safe nothrow { return 0; }
+        override bool isAlerted() shared @safe nothrow { return false; }
+        override void alert() shared @safe nothrow {}
+        override void clearAlert() shared @safe nothrow {}
+        override void checkAlert() shared @safe nothrow {}
     }
 
     enum theTimeout = 50; // milliseconds

--- a/source/disruptor/waitstrategy.d
+++ b/source/disruptor/waitstrategy.d
@@ -49,12 +49,12 @@ unittest
     // simple barrier implementation
     class DummySequenceBarrier : SequenceBarrier
     {
-        override long waitFor(long sequence) shared { return 0; }
-        override long getCursor() shared { return 0; }
-        override bool isAlerted() shared { return false; }
-        override void alert() shared {}
-        override void clearAlert() shared {}
-        override void checkAlert() shared {}
+        override long waitFor(long sequence) shared @safe nothrow { return 0; }
+        override long getCursor() shared @safe nothrow { return 0; }
+        override bool isAlerted() shared @safe nothrow { return false; }
+        override void alert() shared @safe nothrow {}
+        override void clearAlert() shared @safe nothrow {}
+        override void checkAlert() shared @safe nothrow {}
     }
 
     auto strategy = new shared BusySpinWaitStrategy();

--- a/source/disruptor/yieldingwaitstrategy.d
+++ b/source/disruptor/yieldingwaitstrategy.d
@@ -49,12 +49,12 @@ unittest
 
     class DummySequenceBarrier : SequenceBarrier
     {
-        override long waitFor(long sequence) shared { return 0; }
-        override long getCursor() shared { return 0; }
-        override bool isAlerted() shared { return false; }
-        override void alert() shared {}
-        override void clearAlert() shared {}
-        override void checkAlert() shared {}
+        override long waitFor(long sequence) shared @safe nothrow { return 0; }
+        override long getCursor() shared @safe nothrow { return 0; }
+        override bool isAlerted() shared @safe nothrow { return false; }
+        override void alert() shared @safe nothrow {}
+        override void clearAlert() shared @safe nothrow {}
+        override void checkAlert() shared @safe nothrow {}
     }
 
     auto strategy = new shared YieldingWaitStrategy();


### PR DESCRIPTION
## Summary
- add `@safe` and `nothrow` to BatchRewindStrategy
- mark simple rewind strategies with these attributes
- tag dummy `SequenceBarrier` helpers in unit tests with safety

## Testing
- `dub build`
- `dub test`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687388185f9c832cbfa2f639df99c3d0