### PR TITLE
Replace Thread.yield with pause

### DIFF
--- a/source/disruptor/multiproducersequencer.d
+++ b/source/disruptor/multiproducersequencer.d
@@ -1,6 +1,6 @@
 module disruptor.multiproducersequencer;
 
-import core.atomic : MemoryOrder, atomicLoad, atomicStore;
+import core.atomic : MemoryOrder, atomicLoad, atomicStore, pause;
 import core.thread : Thread;
 import disruptor.sequence : Sequence;
 import disruptor.waitstrategy : WaitStrategy;
@@ -80,7 +80,7 @@ public:
             long gatingSequence;
             while (wrapPoint > (gatingSequence = utilGetMinimumSequence(gatingSequences, current)))
             {
-                Thread.yield();
+                pause();
             }
             gatingSequenceCache.set(gatingSequence);
         }

--- a/source/disruptor/singleproducersequencer.d
+++ b/source/disruptor/singleproducersequencer.d
@@ -1,7 +1,7 @@
 module disruptor.singleproducersequencer;
 
 import core.thread : Thread;
-import core.atomic : MemoryOrder, atomicLoad, atomicStore, atomicOp;
+import core.atomic : MemoryOrder, atomicLoad, atomicStore, atomicOp, pause;
 import disruptor.sequence : Sequence;
 import disruptor.waitstrategy : WaitStrategy;
 import disruptor.sequencer : Sequencer;
@@ -81,7 +81,7 @@ public:
             long minSequence;
             while (wrapPoint > (minSequence = utilGetMinimumSequence(gatingSequences, nextValue)))
             {
-                Thread.yield();
+                pause();
             }
             atomicStore!(MemoryOrder.rel)(this.cachedValue, minSequence);
         }


### PR DESCRIPTION
## Summary
- replace `Thread.yield()` with `pause()` for minimal delay
- update imports accordingly

## Testing
- `dub build`
- `dub test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68738ea82078832cbd2a30636adae801