### PR TITLE
Add shared AlertException module

### DIFF
--- a/source/disruptor/alertexception.d
+++ b/source/disruptor/alertexception.d
@@ -1,0 +1,17 @@
+module disruptor.alertexception;
+
+/// Exception thrown when a SequenceBarrier is alerted.
+class AlertException : Exception
+{
+    static __gshared AlertException INSTANCE;
+
+    this(string msg = "Alerted", string file = __FILE__, size_t line = __LINE__)
+    {
+        super(msg, file, line);
+    }
+}
+
+shared static this()
+{
+    AlertException.INSTANCE = new AlertException();
+}

--- a/source/disruptor/batcheventprocessor.d
+++ b/source/disruptor/batcheventprocessor.d
@@ -6,7 +6,7 @@ import disruptor.sequence : Sequence;
 import disruptor.sequencer : DataProvider, SequenceBarrier;
 import disruptor.eventprocessor : EventProcessor;
 import disruptor.timeoutexception : TimeoutException;
-import disruptor.processingsequencebarrier : AlertException;
+import disruptor.alertexception : AlertException;
 import disruptor.ringbuffer : RingBuffer; // for unittests
 import disruptor.rewindableexception : RewindableException;
 import disruptor.rewindhandler : RewindHandler;

--- a/source/disruptor/package.d
+++ b/source/disruptor/package.d
@@ -10,6 +10,7 @@ public import disruptor.processingsequencebarrier;
 public import disruptor.waitstrategy;
 public import disruptor.util;
 public import disruptor.insufficientcapacityexception;
+public import disruptor.alertexception;
 public import disruptor.multiproducersequencer;
 public import disruptor.singleproducersequencer;
 public import disruptor.eventfactory;

--- a/source/disruptor/processingsequencebarrier.d
+++ b/source/disruptor/processingsequencebarrier.d
@@ -5,15 +5,7 @@ import disruptor.sequence : Sequence;
 import disruptor.fixedsequencegroup : FixedSequenceGroup;
 import disruptor.waitstrategy : WaitStrategy;
 import disruptor.sequencer : Sequencer, SequenceBarrier, DataProvider, EventPoller;
-
-/// Exception thrown when a SequenceBarrier is alerted.
-class AlertException : Exception
-{
-    this(string msg = "Alerted", string file = __FILE__, size_t line = __LINE__)
-    {
-        super(msg, file, line);
-    }
-}
+import disruptor.alertexception : AlertException;
 
 /// Coordination barrier for tracking a cursor and dependent sequences.
 class ProcessingSequenceBarrier : SequenceBarrier
@@ -101,7 +93,7 @@ public:
     {
         if (atomicLoad!(MemoryOrder.acq)(_alerted))
         {
-            throw new AlertException();
+            throw AlertException.INSTANCE;
         }
     }
 }


### PR DESCRIPTION
## Summary
- create `alertexception.d` with a shared `AlertException.INSTANCE`
- update `ProcessingSequenceBarrier` to use the shared instance
- adjust imports to reference the new module
- expose `alertexception` in `package.d`

## Testing
- `dub build`
- `dub test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68738e92a2c4832c8967a208dadb62f4