### PR TITLE
Add safety attributes to simple methods

### DIFF
--- a/source/disruptor/batcheventprocessor.d
+++ b/source/disruptor/batcheventprocessor.d
@@ -99,7 +99,7 @@ public:
                                                 rewindStrategy);
     }
 
-    override shared(Sequence) getSequence() shared
+    override shared(Sequence) getSequence() shared @safe nothrow @nogc
     {
         return _sequence;
     }
@@ -110,7 +110,7 @@ public:
         _sequenceBarrier.alert();
     }
 
-    override bool isRunning() shared
+    override bool isRunning() shared @safe nothrow @nogc
     {
         return atomicLoad!(MemoryOrder.acq)(_running) != RunningState.IDLE;
     }

--- a/source/disruptor/batcheventprocessorbuilder.d
+++ b/source/disruptor/batcheventprocessorbuilder.d
@@ -18,7 +18,7 @@ private:
 
 public:
     /// Set the maximum number of events that will be processed in a batch before updating the sequence.
-    BatchEventProcessorBuilder setMaxBatchSize(int maxBatchSize)
+    BatchEventProcessorBuilder setMaxBatchSize(int maxBatchSize) @safe nothrow @nogc
     {
         _maxBatchSize = maxBatchSize;
         return this;

--- a/source/disruptor/multiproducersequencer.d
+++ b/source/disruptor/multiproducersequencer.d
@@ -30,13 +30,13 @@ public:
         indexShift = log2(bufferSize);
     }
 
-    override bool hasAvailableCapacity(int requiredCapacity) shared
+    override bool hasAvailableCapacity(int requiredCapacity) shared @safe nothrow @nogc
     {
         return hasAvailableCapacity(gatingSequences, requiredCapacity, cursor.get());
     }
 
 private:
-    bool hasAvailableCapacity(shared Sequence[] gatingSequences, int requiredCapacity, long cursorValue) shared
+    bool hasAvailableCapacity(shared Sequence[] gatingSequences, int requiredCapacity, long cursorValue) shared @safe nothrow @nogc
     {
         long wrapPoint = (cursorValue + requiredCapacity) - bufferSize;
         long cachedGatingSequence = gatingSequenceCache.get();
@@ -55,7 +55,7 @@ private:
     }
 
 public:
-    override void claim(long sequence) shared
+    override void claim(long sequence) shared @safe nothrow @nogc
     {
         cursor.set(sequence);
     }
@@ -112,7 +112,7 @@ public:
         return next;
     }
 
-    override long remainingCapacity() shared
+    override long remainingCapacity() shared @safe nothrow @nogc
     {
         long consumed = utilGetMinimumSequence(gatingSequences, cursor.get());
         long produced = cursor.get();
@@ -135,25 +135,25 @@ public:
     }
 
 private:
-    void setAvailable(long sequence) shared
+    void setAvailable(long sequence) shared @safe nothrow @nogc
     {
         setAvailableBufferValue(calculateIndex(sequence), calculateAvailabilityFlag(sequence));
     }
 
-    void setAvailableBufferValue(int index, int flag) shared
+    void setAvailableBufferValue(int index, int flag) shared @safe nothrow @nogc
     {
         atomicStore!(MemoryOrder.rel)(availableBuffer[index], flag);
     }
 
 public:
-    override bool isAvailable(long sequence) shared
+    override bool isAvailable(long sequence) shared @safe nothrow @nogc
     {
         int index = calculateIndex(sequence);
         int flag = calculateAvailabilityFlag(sequence);
         return atomicLoad!(MemoryOrder.acq)(availableBuffer[index]) == flag;
     }
 
-    override long getHighestPublishedSequence(long lowerBound, long availableSequence) shared
+    override long getHighestPublishedSequence(long lowerBound, long availableSequence) shared @safe nothrow @nogc
     {
         for (long sequence = lowerBound; sequence <= availableSequence; sequence++)
         {
@@ -164,12 +164,12 @@ public:
     }
 
 private:
-    int calculateAvailabilityFlag(long sequence) const shared
+    int calculateAvailabilityFlag(long sequence) const shared @safe nothrow @nogc
     {
         return cast(int)(sequence >>> indexShift);
     }
 
-    int calculateIndex(long sequence) const shared
+    int calculateIndex(long sequence) const shared @safe nothrow @nogc
     {
         return cast(int)sequence & indexMask;
     }

--- a/source/disruptor/noopeventprocessor.d
+++ b/source/disruptor/noopeventprocessor.d
@@ -22,17 +22,17 @@ public:
         _sequence = new shared SequencerFollowingSequence(cursor);
     }
 
-    override shared(Sequence) getSequence() shared
+    override shared(Sequence) getSequence() shared @safe nothrow @nogc
     {
         return _sequence;
     }
 
-    override void halt() shared
+    override void halt() shared @safe nothrow @nogc
     {
         atomicStore!(MemoryOrder.rel)(_running, false);
     }
 
-    override bool isRunning() shared
+    override bool isRunning() shared @safe nothrow @nogc
     {
         return atomicLoad!(MemoryOrder.acq)(_running);
     }

--- a/source/disruptor/processingsequencebarrier.d
+++ b/source/disruptor/processingsequencebarrier.d
@@ -68,12 +68,12 @@ public:
         return _sequencer.getHighestPublishedSequence(sequence, availableSequence);
     }
 
-    override long getCursor() shared
+    override long getCursor() shared @safe nothrow @nogc
     {
         return _dependentSequence.get();
     }
 
-    override bool isAlerted() shared
+    override bool isAlerted() shared @safe nothrow @nogc
     {
         return atomicLoad!(MemoryOrder.acq)(_alerted);
     }
@@ -84,7 +84,7 @@ public:
         _waitStrategy.signalAllWhenBlocking();
     }
 
-    override void clearAlert() shared
+    override void clearAlert() shared @safe nothrow @nogc
     {
         atomicStore!(MemoryOrder.rel)(_alerted, false);
     }

--- a/source/disruptor/ringbuffer.d
+++ b/source/disruptor/ringbuffer.d
@@ -134,7 +134,7 @@ public:
         sequencer.publish(lo, hi);
     }
 
-    override int getBufferSize()
+    override int getBufferSize() @safe nothrow @nogc
     {
         return bufferSize;
     }

--- a/source/disruptor/singleproducersequencer.d
+++ b/source/disruptor/singleproducersequencer.d
@@ -27,13 +27,13 @@ public:
         super(bufferSize, waitStrategy);
     }
 
-    override bool hasAvailableCapacity(int requiredCapacity) shared
+    override bool hasAvailableCapacity(int requiredCapacity) shared @safe nothrow @nogc
     {
         return hasAvailableCapacity(requiredCapacity, false);
     }
 
 private:
-    bool hasAvailableCapacity(int requiredCapacity, bool doStore) shared
+    bool hasAvailableCapacity(int requiredCapacity, bool doStore) shared @safe nothrow @nogc
     {
         long nextValue = atomicLoad!(MemoryOrder.acq)(this.nextValue);
         long wrapPoint = (nextValue + requiredCapacity) - bufferSize;
@@ -107,7 +107,7 @@ public:
         return nextSequence;
     }
 
-    override long remainingCapacity() shared
+    override long remainingCapacity() shared @safe nothrow @nogc
     {
         long nextValue = atomicLoad!(MemoryOrder.acq)(this.nextValue);
         long consumed = utilGetMinimumSequence(gatingSequences, nextValue);
@@ -115,7 +115,7 @@ public:
         return bufferSize - (produced - consumed);
     }
 
-    override void claim(long sequence) shared
+    override void claim(long sequence) shared @safe nothrow @nogc
     {
         atomicStore!(MemoryOrder.rel)(this.nextValue, sequence);
     }
@@ -131,13 +131,13 @@ public:
         publish(hi);
     }
 
-    override bool isAvailable(long sequence) shared
+    override bool isAvailable(long sequence) shared @safe nothrow @nogc
     {
         long currentSequence = cursor.get();
         return sequence <= currentSequence && sequence > currentSequence - bufferSize;
     }
 
-    override long getHighestPublishedSequence(long lowerBound, long availableSequence) shared
+    override long getHighestPublishedSequence(long lowerBound, long availableSequence) shared @safe nothrow @nogc
     {
         return availableSequence;
     }


### PR DESCRIPTION
## Summary
- mark simple getters and checks @safe, nothrow, and @nogc
- update BatchEventProcessor builder and processor implementations
- tighten attributes on producer sequencers and helper classes

## Testing
- `dub build`
- `dub test`

------
https://chatgpt.com/codex/tasks/task_e_68739c2bca20832ca993979733b01456