### PR TITLE
Add consumer repository utilities

### DIFF
--- a/source/disruptor/consumerinfo.d
+++ b/source/disruptor/consumerinfo.d
@@ -1,0 +1,26 @@
+module disruptor.consumerinfo;
+
+import disruptor.sequence : Sequence;
+import disruptor.sequencer : SequenceBarrier;
+import core.thread : Thread;
+
+alias Runnable = void delegate();
+
+/// Interface for creating threads.
+interface ThreadFactory
+{
+    Thread newThread(Runnable r) shared;
+}
+
+/// Interface describing a consumer of events.
+interface ConsumerInfo
+{
+    shared(Sequence)[] getSequences() shared;
+    shared(SequenceBarrier) getBarrier() shared;
+    bool isEndOfChain() shared;
+    void start(shared ThreadFactory threadFactory) shared;
+    void halt() shared;
+    void markAsUsedInBarrier() shared;
+    bool isRunning() shared;
+}
+

--- a/source/disruptor/consumerrepository.d
+++ b/source/disruptor/consumerrepository.d
@@ -1,0 +1,237 @@
+module disruptor.consumerrepository;
+
+import std.exception : enforce;
+import disruptor.eventprocessor : EventProcessor;
+import disruptor.sequence : Sequence;
+import disruptor.sequencer : SequenceBarrier;
+import disruptor.eventhandler : EventHandlerIdentity;
+import disruptor.consumerinfo : ConsumerInfo, ThreadFactory;
+import disruptor.eventprocessorinfo : EventProcessorInfo;
+
+/// Repository associating `EventHandler` instances with their `EventProcessor`s.
+class ConsumerRepository
+{
+private:
+    shared(EventProcessorInfo)[EventHandlerIdentity] _infoByHandler;
+    shared(ConsumerInfo)[shared Sequence] _infoBySequence;
+    shared ConsumerInfo[] _consumerInfos;
+
+public:
+    void add(shared EventProcessor processor,
+             shared EventHandlerIdentity handlerIdentity,
+             shared SequenceBarrier barrier)
+    {
+        auto info = new shared EventProcessorInfo(processor, barrier);
+        _infoByHandler[cast(EventHandlerIdentity)handlerIdentity] = info;
+        _infoBySequence[processor.getSequence()] = info;
+        _consumerInfos ~= info;
+    }
+
+    void add(shared EventProcessor processor)
+    {
+        auto info = new shared EventProcessorInfo(processor, null);
+        _infoBySequence[processor.getSequence()] = info;
+        _consumerInfos ~= info;
+    }
+
+    void startAll(shared ThreadFactory threadFactory)
+    {
+        foreach (info; _consumerInfos)
+            info.start(threadFactory);
+    }
+
+    void haltAll()
+    {
+        foreach (info; _consumerInfos)
+            info.halt();
+    }
+
+    bool hasBacklog(long cursor, bool includeStopped)
+    {
+        foreach (info; _consumerInfos)
+        {
+            if ((includeStopped || info.isRunning()) && info.isEndOfChain())
+            {
+                foreach (seq; info.getSequences())
+                {
+                    if (cursor > seq.get())
+                        return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    shared(EventProcessor) getEventProcessorFor(shared EventHandlerIdentity handlerIdentity)
+    {
+        auto infoPtr = cast(EventHandlerIdentity)handlerIdentity in _infoByHandler;
+        enforce(infoPtr !is null, "The event handler is not processing events.", __FILE__, __LINE__);
+        return (*infoPtr).getEventProcessor();
+    }
+
+    shared(Sequence) getSequenceFor(shared EventHandlerIdentity handlerIdentity)
+    {
+        return getEventProcessorFor(handlerIdentity).getSequence();
+    }
+
+    void unMarkEventProcessorsAsEndOfChain(shared Sequence[] barrierEventProcessors)
+    {
+        foreach (seq; barrierEventProcessors)
+        {
+            auto infoPtr = seq in _infoBySequence;
+            if (infoPtr !is null)
+                (*infoPtr).markAsUsedInBarrier();
+        }
+    }
+
+    shared(SequenceBarrier) getBarrierFor(shared EventHandlerIdentity handlerIdentity)
+    {
+        auto infoPtr = cast(EventHandlerIdentity)handlerIdentity in _infoByHandler;
+        return infoPtr !is null ? (*infoPtr).getBarrier() : null;
+    }
+}
+
+
+unittest
+{
+    import disruptor.eventhandler : EventHandler;
+    import core.thread : Thread;
+
+    class StubHandler : EventHandler!int
+    {
+        override void onEvent(int evt, long seq, bool endOfBatch) shared {}
+    }
+
+    class StubProcessor : EventProcessor
+    {
+        private shared Sequence seq;
+        private shared bool running;
+
+        this() shared
+        {
+            seq = new shared Sequence();
+        }
+
+        override void run() shared { running = true; }
+        override shared(Sequence) getSequence() shared { return seq; }
+        override void halt() shared { running = false; }
+        override bool isRunning() shared { return running; }
+    }
+
+    class StubThreadFactory : ThreadFactory
+    {
+        shared Thread[] threads;
+        override Thread newThread(void delegate() r) shared
+        {
+            auto t = new Thread(r);
+            threads ~= cast(shared) t;
+            return t;
+        }
+    }
+    auto repo = new ConsumerRepository();
+    auto handler = new shared StubHandler();
+    auto processor = new shared StubProcessor();
+    repo.add(processor, handler, null);
+
+    assert(repo.getEventProcessorFor(handler) is processor);
+    assert(repo.getSequenceFor(handler) is processor.getSequence());
+}
+
+unittest
+{
+    import disruptor.eventhandler : EventHandler;
+    import core.thread : Thread;
+    class StubHandler : EventHandler!int
+    {
+        override void onEvent(int evt, long seq, bool endOfBatch) shared {}
+    }
+
+    class StubProcessor : EventProcessor
+    {
+        private shared Sequence seq;
+        private shared bool running;
+        this() shared { seq = new shared Sequence(); }
+        override void run() shared { running = true; }
+        override shared(Sequence) getSequence() shared { return seq; }
+        override void halt() shared { running = false; }
+        override bool isRunning() shared { return running; }
+    }
+
+    class StubThreadFactory : ThreadFactory
+    {
+        shared Thread[] threads;
+        override Thread newThread(void delegate() r) shared
+        {
+            auto t = new Thread(r);
+            threads ~= cast(shared) t;
+            return t;
+        }
+    }
+
+
+    auto repo = new ConsumerRepository();
+    auto handler = new shared StubHandler();
+    auto processor = new shared StubProcessor();
+    repo.add(processor, handler, null);
+
+    auto factory = new shared StubThreadFactory();
+    repo.startAll(factory);
+    foreach (t; factory.threads) (cast(Thread)t).join();
+    assert(processor.isRunning());
+    repo.haltAll();
+    assert(!processor.isRunning());
+}
+
+unittest
+{
+    import disruptor.eventhandler : EventHandler;
+    import core.thread : Thread;
+    class StubHandler : EventHandler!int
+    {
+        override void onEvent(int evt, long seq, bool endOfBatch) shared {}
+    }
+
+    class StubProcessor : EventProcessor
+    {
+        private shared Sequence seq;
+        private shared bool running;
+        this() shared { seq = new shared Sequence(); }
+        override void run() shared { running = true; }
+        override shared(Sequence) getSequence() shared { return seq; }
+        override void halt() shared { running = false; }
+        override bool isRunning() shared { return running; }
+    }
+
+    class StubThreadFactory : ThreadFactory
+    {
+        shared Thread[] threads;
+        override Thread newThread(void delegate() r) shared
+        {
+            auto t = new Thread(r);
+            threads ~= cast(shared) t;
+            return t;
+        }
+    }
+
+    auto repo = new ConsumerRepository();
+    auto handler1 = new shared StubHandler();
+    auto handler2 = new shared StubHandler();
+    auto p1 = new shared StubProcessor();
+    auto p2 = new shared StubProcessor();
+    repo.add(p1, handler1, null);
+    repo.add(p2, handler2, null);
+
+    auto factory = new shared StubThreadFactory();
+    repo.startAll(factory);
+    foreach (t; factory.threads) (cast(Thread)t).join();
+
+    p1.getSequence().set(8);
+    p2.getSequence().set(10);
+    long cursor = 10;
+
+    assert(repo.hasBacklog(cursor, false));
+    p1.halt();
+    assert(!repo.hasBacklog(cursor, false));
+    assert(repo.hasBacklog(cursor, true));
+}
+

--- a/source/disruptor/eventprocessorinfo.d
+++ b/source/disruptor/eventprocessorinfo.d
@@ -1,0 +1,68 @@
+module disruptor.eventprocessorinfo;
+
+import std.conv : text;
+import core.thread : Thread;
+import disruptor.eventprocessor : EventProcessor;
+import disruptor.sequence : Sequence;
+import disruptor.sequencer : SequenceBarrier;
+import disruptor.consumerinfo : ConsumerInfo, ThreadFactory;
+
+/// Wrapper tying an `EventProcessor` to its `SequenceBarrier`.
+class EventProcessorInfo : ConsumerInfo
+{
+private:
+    shared(EventProcessor) _eventProcessor;
+    shared SequenceBarrier _barrier;
+    shared bool _endOfChain = true;
+
+public:
+    this(shared EventProcessor eventProcessor, shared SequenceBarrier barrier) shared @safe nothrow
+    {
+        _eventProcessor = eventProcessor;
+        _barrier = barrier;
+    }
+
+    shared(EventProcessor) getEventProcessor() shared @safe nothrow
+    {
+        return _eventProcessor;
+    }
+
+    override shared(Sequence)[] getSequences() shared
+    {
+        return [_eventProcessor.getSequence()];
+    }
+
+    override shared(SequenceBarrier) getBarrier() shared
+    {
+        return _barrier;
+    }
+
+    override bool isEndOfChain() shared
+    {
+        return _endOfChain;
+    }
+
+    override void start(shared ThreadFactory threadFactory) shared
+    {
+        auto thread = threadFactory.newThread({ _eventProcessor.run(); });
+        if (thread is null)
+            throw new Exception("Failed to create thread to run", __FILE__, __LINE__);
+        thread.start();
+    }
+
+    override void halt() shared
+    {
+        _eventProcessor.halt();
+    }
+
+    override void markAsUsedInBarrier() shared
+    {
+        _endOfChain = false;
+    }
+
+    override bool isRunning() shared
+    {
+        return _eventProcessor.isRunning();
+    }
+}
+

--- a/source/disruptor/package.d
+++ b/source/disruptor/package.d
@@ -44,3 +44,6 @@ public import disruptor.rewindbatcheventprocessor;
 public import disruptor.fatalexceptionhandler;
 public import disruptor.exceptionhandlers;
 public import disruptor.batcheventprocessorbuilder;
+public import disruptor.consumerinfo;
+public import disruptor.eventprocessorinfo;
+public import disruptor.consumerrepository;


### PR DESCRIPTION
## Summary
- port consumer management classes from the Java DSL
- support starting processors via a thread factory
- expose the new modules in package.d
- test consumer repository behaviour

## Testing
- `dub build`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_6873a879afd0832cb82699f980764df1